### PR TITLE
Add flake8 excludes to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,6 @@ commands =
 deps=pytest-cov
     -r{toxinidir}/dev-requirements.txt
 commands = py.test --cov=etcd3 tests/
+
+[flake8]
+exclude =  .venv,.git,.tox,dist,docs,*lib/python*,*egg,build,etcd3/etcdrpc/


### PR DESCRIPTION
Exclude the generated python code, docs files and a bunch of generic
python dirs from being included in flake8 tests.