### PR TITLE
Add docker-compose to run etcd and tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python
+
+ARG HTTP_PROXY
+ARG http_proxy
+ARG HTTPS_PROXY
+ARG https_proxy
+
+RUN curl -L http://github.com/coreos/etcd/releases/download/v3.0.10/etcd-v3.0.10-linux-amd64.tar.gz | tar xzvf -
+ENV PATH $PATH:/etcd-v3.0.10-linux-amd64
+
+RUN pip install -U tox
+
+RUN mkdir python-etcd3
+WORKDIR python-etcd3
+# Rebuild this layer .tox when tox.ini or dev-requirements.txt changes
+COPY tox.ini dev-requirements.txt ./
+
+RUN tox -epy35 --notest
+
+COPY . ./
+
+ENV ETCDCTL_API 3
+CMD ["tox", "-epy35"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  python:
+    build:
+      context: .
+      args:
+        - HTTP_PROXY
+        - http_proxy
+        - HTTPS_PROXY
+        - https_proxy
+    links:
+      - etcd
+    environment:
+      - ETCD_ENDPOINT=http://etcd:2379
+  etcd:
+    ports:
+      - "2379:2379"
+    image: quay.io/coreos/etcd
+    command: etcd --initial-cluster-state new --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://127.0.0.1:2379

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -137,6 +137,6 @@ class Etcd3Client(object):
         pass
 
 
-def client():
+def client(host='localhost', port=2379):
     '''Return an instance of an Etcd3Client'''
-    return Etcd3Client(host='localhost', port=2379)
+    return Etcd3Client(host=host, port=port)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27, py34, py35, flake8
+skipsdist=True
 
 [testenv:flake8]
 basepython=python
@@ -7,6 +8,7 @@ deps=flake8
 commands=flake8 etcd3
 
 [testenv]
+passenv = ETCD_ENDPOINT
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/etcd3
 deps=pytest-cov


### PR DESCRIPTION
On many systems running etcd is a burden of a requirement, in this setup
you can run etcd in a container and also if required run your tests in a
container with the 'etcdctl' binary.

The tests support an optional etcd enpoint environment variable
'ETCD_ENDPOINT'. If this is supplied then this is is the endpoint that
is connected to.

You can run the full test suite with `docker-compose up` which will
leave the system running. To run etcd up in the background, use `docker-compose up -d
etcd`, this will expose etcd on port 2379 on your localhost.

Once you have a etcd cluster to use the tests can either be ran locally
using the standard `tox` command and using the env var `ETCD_ENDPOINT`
or you can run the test in the docker container if you do not have the
`etcdctl` binary available. This can be done with `docker-compose up
python`.

If a code change is made the 'python' container will need to be rebuilt,
this should be instant process if the `tox.ini` and
`dev-requirements.txt` have not changed. Run `docker-compose build` to
rebuild the container with the new code.