### PR TITLE
Separate dev-requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Editor files
+.sw?

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
+include test-requirements.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,7 @@ pip==8.1.2
 bumpversion==0.5.3
 wheel==0.29.0
 watchdog==0.8.3
-flake8==3.0.4
-tox==2.3.1
-coverage==4.2
 Sphinx==1.4.8
 PyYAML==3.12
-pytest==3.0.3
 grpcio==1.0.0
 grpcio-tools==1.0.0
-hypothesis==3.5.3

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import re
 from setuptools import setup
 
 with open('README.rst') as readme_file:
@@ -9,14 +10,15 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [
-    'six',
-    'grpcio',
-]
+def load_reqs(filename):
+    with open(filename) as reqs_file:
+        return [
+            re.sub('==', '>=', line) for line in reqs_file.readlines()
+            if not re.match('\s*#', line)
+        ]
 
-test_requirements = [
-    'pytest',
-]
+requirements = load_reqs('requirements.txt')
+test_requirements = load_reqs('test-requirements.txt')
 
 setup(
     name='etcd3',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+flake8==3.0.4
+tox==2.3.1
+coverage==4.2
+pytest==3.0.3
+hypothesis==3.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,16 @@ commands=flake8 etcd3
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/etcd3
 deps=pytest-cov
-    -r{toxinidir}/dev-requirements.txt
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands =
     pip install -U pip
     py.test --cov=etcd3 --cov-report= --basetemp={envtmpdir}
 
 [testenv:coverage]
 deps=pytest-cov
-    -r{toxinidir}/dev-requirements.txt
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands = py.test --cov=etcd3 tests/
 
 [flake8]


### PR DESCRIPTION
Split dev-requirements.txt into requirements.txt and
test-requirements.txt. Add these files to MANIFEST.in.

Load these files in setup.py to fulfill install_requires, with open
versions to make it easier to install.

Incidentally, add .sw? to .gitignore.