### PR TITLE
Use fixtures for getting client in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=pytest-cov
     -r{toxinidir}/test-requirements.txt
 commands =
     pip install -U pip
-    py.test --cov=etcd3 --cov-report= --basetemp={envtmpdir}
+    py.test --cov=etcd3 --cov-report= --basetemp={envtmpdir} {posargs}
 
 [testenv:coverage]
 deps=pytest-cov


### PR DESCRIPTION
Tests were not all using the correct client causing docker-compose test
runs to fail. We now used fixtures!