### PR TITLE
Use test-requirements.txt for flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ envlist = py27, py34, py35, flake8
 skipsdist=True
 
 [testenv:flake8]
-basepython=python
-deps=flake8
-commands=flake8
+commands=flake8 {posargs}
 
 [testenv]
 passenv = ETCD_ENDPOINT
@@ -27,3 +25,4 @@ commands = py.test --cov=etcd3 tests/
 [flake8]
 exclude =  .venv,.git,.tox,dist,docs,*lib/python*,*egg,build,etcd3/etcdrpc/
 application-import-names = etcd3
+max-complexity = 10


### PR DESCRIPTION
Flake8 was not picking up flake8-import-order plugin as it was using the
hard dependency of 'flake8' only.

Also set the 'max-complexity' allowed for a method to 10. This is the
cyclomatic complexity checked by the mccabe plugin.