### PR TITLE
Refactor watch functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,16 +67,27 @@ Basic usage:
 
     # watch key
     watch_count = 0
-    for (event, cancel) in etcd.watch("/doot/watch"):
-        print event
+    events_iterator, cancel = etcd.watch("/doot/watch")
+    for event in events_iterator:
+        print(event)
         watch_count += 1
         if watch_count > 10:
             cancel()
 
     # watch prefix
     watch_count = 0
-    for (event, cancel) in etcd.watch_prefix("/doot/watch/prefix/"):
-        print event
+    events_iterator, cancel = etcd.watch_prefix("/doot/watch/prefix/")
+    for event in events_iterator:
+        print(event)
         watch_count += 1
         if watch_count > 10:
             cancel()
+
+    # recieve watch events via callback function
+    def watch_callback(event):
+        print(event)
+
+    watch_id = etcd.add_watch_callback("/anotherkey", watch_callback)
+
+    # cancel watch
+    etcd.cancel_watch(watch_id)

--- a/etcd3/events.py
+++ b/etcd3/events.py
@@ -1,5 +1,4 @@
 class Event(object):
-    __impl = {}
 
     def __init__(self, event):
         self.key = event.kv.key

--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -1,2 +1,10 @@
-class KeyNotFoundError(Exception):
+class Etcd3Exception(Exception):
+    pass
+
+
+class KeyNotFoundError(Etcd3Exception):
+    pass
+
+
+class WatchTimedOut(Etcd3Exception):
     pass

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -1,0 +1,84 @@
+import threading
+
+import grpc
+
+from six.moves import queue
+
+import etcd3.etcdrpc as etcdrpc
+import etcd3.events as events
+import etcd3.utils as utils
+
+
+class Watcher(threading.Thread):
+
+    def __init__(self, watchstub):
+        threading.Thread.__init__(self)
+        self.__watch_id_callbacks = {}
+        self.__watch_id_queue = queue.Queue()
+        self.__watch_id_lock = threading.Lock()
+        self.__watch_requests_queue = queue.Queue()
+        self.__watch_response_iterator = \
+            watchstub.Watch(self.__requests_iterator)
+        self.__callback = None
+        self.daemon = True
+        self.start()
+
+    def run(self):
+        try:
+            for response in self.__watch_response_iterator:
+                if response.created and self.__callback:
+                    self.__watch_id_callbacks[response.watch_id] = \
+                        self.__callback
+                    self.__watch_id_queue.put(response.watch_id)
+
+                callback = self.__watch_id_callbacks.get(response.watch_id)
+                if callback:
+                    for event in response.events:
+                        callback(events.new_event(event))
+        except grpc.RpcError:
+            self.cancel()
+
+    @property
+    def __requests_iterator(self):
+        while True:
+            request, self.__callback = self.__watch_requests_queue.get()
+            if request is None:
+                break
+            yield request
+
+    def add_callback(self, key, callback,
+                     range_end=None,
+                     start_revision=None,
+                     progress_notify=False,
+                     filters=None,
+                     prev_kv=False):
+        if callback:
+            self.__watch_id_lock.acquire()
+        create_watch = etcdrpc.WatchCreateRequest()
+        create_watch.key = utils.to_bytes(key)
+        if range_end is not None:
+            create_watch.range_end = utils.to_bytes(range_end)
+        if start_revision is not None:
+            create_watch.start_revision = start_revision
+        if progress_notify:
+            create_watch.progress_notify = progress_notify
+        if filters is not None:
+            create_watch.filters = filters
+        if prev_kv:
+            create_watch.prev_kv = prev_kv
+        request = etcdrpc.WatchRequest(create_request=create_watch)
+        self.__watch_requests_queue.put((request, callback))
+        if callback:
+            watch_id = self.__watch_id_queue.get()
+            self.__watch_id_lock.release()
+            return watch_id
+
+    def cancel(self, watch_id=None):
+        if watch_id is None:
+            request = None
+        else:
+            self.__watch_id_callbacks.pop(watch_id, None)
+            cancel_watch = etcdrpc.WatchCancelRequest()
+            cancel_watch.watch_id = watch_id
+            request = etcdrpc.WatchRequest(cancel_request=cancel_watch)
+        self.__watch_requests_queue.put((request, None))

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -114,7 +114,8 @@ class TestEtcd3(object):
         t.start()
 
         change_count = 0
-        for (event, cancel) in etcd.watch(b'/doot/watch'):
+        events_iterator, cancel = etcd.watch(b'/doot/watch')
+        for event in events_iterator:
             assert event.key == b'/doot/watch'
             assert event.value == \
                 utils.to_bytes(str(change_count))
@@ -152,7 +153,8 @@ class TestEtcd3(object):
         t.start()
 
         change_count = 0
-        for (event, cancel) in etcd.watch_prefix('/doot/watch/prefix/'):
+        events_iterator, cancel = etcd.watch_prefix('/doot/watch/prefix/')
+        for event in events_iterator:
             assert event.key == \
                 utils.to_bytes('/doot/watch/prefix/{}'.format(change_count))
             assert event.value == \


### PR DESCRIPTION
The old implementation has had several drawbacks:
 * It was not possible to cancel watch until the first event arrived.
 * It was creating a new watch channel for every watch.

So I've tried to fix that:
 * We create communication channels only once and all next watch and cancel requests should go via these channels.
 * it is possible to cancel existing watches without destroying the whole channel
 * depending on the method you will receive immediately either reference to a `cancel` function or a `watch_id` which might be used to cancel watch request (on the server)
 * callbacks and queues are the main building blocks now