### PR TITLE
Don't stop watcher in case of timeout 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ target/
 
 # Editor files
 .sw?
+.idea/

--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -8,3 +8,15 @@ class KeyNotFoundError(Etcd3Exception):
 
 class WatchTimedOut(Etcd3Exception):
     pass
+
+
+class InternalServerErrorException(Etcd3Exception):
+    pass
+
+
+class ConnectionFailedException(Etcd3Exception):
+    pass
+
+
+class ConnectionTimeoutException(Etcd3Exception):
+    pass

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -36,7 +36,7 @@ class Watcher(threading.Thread):
         self._watch_id_lock = threading.Lock()
         self._watch_requests_queue = queue.Queue()
         self._watch_response_iterator = \
-            watchstub.Watch(self._requests_iterator, self.timeout)
+            watchstub.Watch(self._requests_iterator)
         self._callback = None
         self.daemon = True
         self.start()

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -20,6 +20,7 @@ import six
 from six.moves.urllib.parse import urlparse
 
 import etcd3
+import etcd3.exceptions
 import etcd3.etcdrpc as etcdrpc
 import etcd3.utils as utils
 
@@ -49,9 +50,12 @@ class TestEtcd3(object):
     @pytest.fixture
     def etcd(self):
         endpoint = os.environ.get('ETCD_ENDPOINT', None)
+        timeout = 5
         if endpoint:
             url = urlparse(endpoint)
-            yield etcd3.client(host=url.hostname, port=url.port)
+            yield etcd3.client(host=url.hostname,
+                               port=url.port,
+                               timeout=timeout)
         else:
             yield etcd3.client()
 
@@ -170,6 +174,21 @@ class TestEtcd3(object):
                 cancel()
 
         t.join()
+
+    def test_sequential_watch_prefix_once(self, etcd):
+        try:
+            etcd.watch_prefix_once('/doot/', 1)
+        except etcd3.exceptions.WatchTimedOut:
+            pass
+        try:
+            etcd.watch_prefix_once('/doot/', 1)
+        except etcd3.exceptions.WatchTimedOut:
+            pass
+        try:
+            etcd.watch_prefix_once('/doot/', 1)
+        except etcd3.exceptions.WatchTimedOut:
+            pass
+
 
     def test_transaction_success(self, etcd):
         etcdctl('put', '/doot/txn', 'dootdoot')

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -11,8 +11,12 @@ import subprocess
 import threading
 import time
 
+import grpc
+
 from hypothesis import given
 from hypothesis.strategies import characters
+
+import mock
 
 import pytest
 
@@ -20,8 +24,8 @@ import six
 from six.moves.urllib.parse import urlparse
 
 import etcd3
-import etcd3.exceptions
 import etcd3.etcdrpc as etcdrpc
+import etcd3.exceptions
 import etcd3.utils as utils
 
 
@@ -188,7 +192,6 @@ class TestEtcd3(object):
             etcd.watch_prefix_once('/doot/', 1)
         except etcd3.exceptions.WatchTimedOut:
             pass
-
 
     def test_transaction_success(self, etcd):
         etcdctl('put', '/doot/txn', 'dootdoot')
@@ -391,6 +394,39 @@ class TestEtcd3(object):
         lock2.acquire()
         assert lock1.is_acquired() is False
         assert lock2.is_acquired() is True
+
+    def test_proper_exception_on_internal_error(self, etcd):
+        class MockedException(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.INTERNAL
+        kv_mock = mock.MagicMock()
+        kv_mock.Range.side_effect = MockedException()
+        etcd.kvstub = kv_mock
+
+        with pytest.raises(etcd3.exceptions.InternalServerErrorException):
+            etcd.get("foo")
+
+    def test_proper_exception_on_connection_failure(self, etcd):
+        class MockedException(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.UNAVAILABLE
+        kv_mock = mock.MagicMock()
+        kv_mock.Range.side_effect = MockedException()
+        etcd.kvstub = kv_mock
+
+        with pytest.raises(etcd3.exceptions.ConnectionFailedException):
+            etcd.get("foo")
+
+    def test_proper_exception_on_connection_timeout(self, etcd):
+        class MockedException(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.DEADLINE_EXCEEDED
+        kv_mock = mock.MagicMock()
+        kv_mock.Range.side_effect = MockedException()
+        etcd.kvstub = kv_mock
+
+        with pytest.raises(etcd3.exceptions.ConnectionTimeoutException):
+            etcd.get("foo")
 
 
 class TestUtils(object):


### PR DESCRIPTION
Timeout feature is already handled in client.py
Setting timeout on watchstub causes block on all other watches in case one of them timeout's