### PR TITLE
Watch fix in case of timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ target/
 
 # Editor files
 .sw?
+.idea/

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -36,7 +36,7 @@ class Watcher(threading.Thread):
         self._watch_id_lock = threading.Lock()
         self._watch_requests_queue = queue.Queue()
         self._watch_response_iterator = \
-            watchstub.Watch(self._requests_iterator, self.timeout)
+            watchstub.Watch(self._requests_iterator)
         self._callback = None
         self.daemon = True
         self.start()


### PR DESCRIPTION
Right now, when grpc throws timeout, internal Watcher loop will break because of timeout exception. Submitting new callback will block infinitely, because `_watch_id_queue.get()` from `add_callback
()` will never return.

watch_once* already supports timeout feature