### PR TITLE
The 'get' method now returns None when the target key does not exist

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -161,7 +161,7 @@ class Etcd3Client(object):
         range_response = self.kvstub.Range(range_request, self.timeout)
 
         if range_response.count < 1:
-            yield from ()
+            return
         else:
             for kv in range_response.kvs:
                 yield (kv.value, KVMetadata(kv))
@@ -182,7 +182,7 @@ class Etcd3Client(object):
         range_response = self.kvstub.Range(range_request, self.timeout)
 
         if range_response.count < 1:
-            yield from ()
+            return
         else:
             for kv in range_response.kvs:
                 yield (kv.value, KVMetadata(kv))

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -139,8 +139,7 @@ class Etcd3Client(object):
         range_response = self.kvstub.Range(range_request, self.timeout)
 
         if range_response.count < 1:
-            raise exceptions.KeyNotFoundError(
-                'the key "{}" was not found'.format(key))
+            return None, None
         else:
             kv = range_response.kvs.pop()
             return kv.value, KVMetadata(kv)
@@ -162,7 +161,7 @@ class Etcd3Client(object):
         range_response = self.kvstub.Range(range_request, self.timeout)
 
         if range_response.count < 1:
-            raise exceptions.KeyNotFoundError('no keys found')
+            yield from ()
         else:
             for kv in range_response.kvs:
                 yield (kv.value, KVMetadata(kv))
@@ -183,7 +182,7 @@ class Etcd3Client(object):
         range_response = self.kvstub.Range(range_request, self.timeout)
 
         if range_response.count < 1:
-            raise exceptions.KeyNotFoundError('no keys')
+            yield from ()
         else:
             for kv in range_response.kvs:
                 yield (kv.value, KVMetadata(kv))

--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -2,9 +2,5 @@ class Etcd3Exception(Exception):
     pass
 
 
-class KeyNotFoundError(Etcd3Exception):
-    pass
-
-
 class WatchTimedOut(Etcd3Exception):
     pass

--- a/etcd3/locks.py
+++ b/etcd3/locks.py
@@ -97,15 +97,12 @@ class Lock(object):
 
     def is_acquired(self):
         """Check if this lock is currently acquired."""
-        try:
-            uuid, _ = self.etcd_client.get(self.key)
-        except exceptions.KeyNotFoundError:
+        uuid, _ = self.etcd_client.get(self.key)
+
+        if uuid is None:
             return False
 
-        if uuid == self.uuid:
-            return True
-        else:
-            return False
+        return uuid == self.uuid
 
     def __enter__(self):
         self.acquire()

--- a/etcd3/locks.py
+++ b/etcd3/locks.py
@@ -1,7 +1,6 @@
 import time
 import uuid
 
-import etcd3.exceptions as exceptions
 
 lock_prefix = '/locks/'
 

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -63,8 +63,9 @@ class TestEtcd3(object):
         etcdctl('del', '--prefix', '/')
 
     def test_get_unknown_key(self, etcd):
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            etcd.get('probably-invalid-key')
+        value, meta = etcd.get('probably-invalid-key')
+        assert value is None
+        assert meta is None
 
     @given(characters(blacklist_categories=['Cs', 'Cc']))
     def test_get_key(self, etcd, string):
@@ -93,8 +94,8 @@ class TestEtcd3(object):
 
         etcd.delete('/doot/delete_this')
 
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            etcd.get('/doot/delete_this')
+        v, _ = etcd.get('/doot/delete_this')
+        assert v is None
 
     def test_watch_key(self, etcd):
         def update_etcd(v):
@@ -236,15 +237,15 @@ class TestEtcd3(object):
             assert value == b'i am a range'
 
     def test_all_not_found_error(self, etcd):
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            list(etcd.get_all())
+        result = list(etcd.get_all())
+        assert not result
 
     def test_range_not_found_error(self, etcd):
         for i in range(5):
             etcdctl('put', '/doot/notrange{}'.format(i), 'i am a not range')
 
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            list(etcd.get_prefix('/doot/range'))
+        result = list(etcd.get_prefix('/doot/range'))
+        assert not result
 
     def test_get_all(self, etcd):
         for i in range(20):
@@ -315,8 +316,8 @@ class TestEtcd3(object):
 
         # wait for the lease to expire
         time.sleep(lease.granted_ttl + 2)
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            etcd.get(key)
+        v, _ = etcd.get(key)
+        assert v is None
 
     def test_member_list_single(self, etcd):
         # if tests are run against an etcd cluster rather than a single node,
@@ -340,8 +341,8 @@ class TestEtcd3(object):
         assert lock.acquire() is True
         assert etcd.get(lock.key)[0] is not None
         assert lock.release() is True
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            etcd.get(lock.key)
+        v, _ = etcd.get(lock.key)
+        assert v is None
 
     def test_lock_expire(self, etcd):
         lock = etcd.lock('lock-3', ttl=2)
@@ -349,8 +350,8 @@ class TestEtcd3(object):
         assert etcd.get(lock.key)[0] is not None
         # wait for the lease to expire
         time.sleep(6)
-        with pytest.raises(etcd3.exceptions.KeyNotFoundError):
-            etcd.get(lock.key)
+        v, _ = etcd.get(lock.key)
+        assert v is None
 
     def test_lock_refresh(self, etcd):
         lock = etcd.lock('lock-4', ttl=2)


### PR DESCRIPTION
Related to issue #56 

This patch change the behavior of the 'get' method to something more similar to the CoreOS go etcd client.

Instead of dealing with an exception when a key does not exist, the client returns a (None, None) tuple.

I think this is especially useful when checking if a key already exists before creating it. With the current 'get' method:

```python
with etcd.lock('lock'):
    try:
        etcd.get(key_name)
        raise CustomException
    except KeyNotFoundError:
        pass

    etcd.put(key_name, key_value)
```

With the new one:

```python
with etcd.lock('lock'):
    if not etcd.get(key_name)[0]:
        etcd.put(key_name, key_value)
    else:
        raise CustomException
```