### PR TITLE
Add ability to pass multiple endpoints, failover capability

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -1,6 +1,7 @@
 import functools
-import inspect
+import random
 import threading
+import time
 
 import grpc
 import grpc._channel
@@ -23,31 +24,11 @@ _EXCEPTIONS_BY_CODE = {
     grpc.StatusCode.FAILED_PRECONDITION: exceptions.PreconditionFailedError,
 }
 
-
-def _translate_exception(exc):
-    code = exc.code()
-    exception = _EXCEPTIONS_BY_CODE.get(code)
-    if exception is None:
-        raise
-    raise exception
-
-
-def _handle_errors(f):
-    if inspect.isgeneratorfunction(f):
-        def handler(*args, **kwargs):
-            try:
-                for data in f(*args, **kwargs):
-                    yield data
-            except grpc.RpcError as exc:
-                _translate_exception(exc)
-    else:
-        def handler(*args, **kwargs):
-            try:
-                return f(*args, **kwargs)
-            except grpc.RpcError as exc:
-                _translate_exception(exc)
-
-    return functools.wraps(f)(handler)
+_FAILED_EP_CODES = [
+    grpc.StatusCode.UNAVAILABLE,
+    grpc.StatusCode.DEADLINE_EXCEEDED,
+    grpc.StatusCode.INTERNAL
+]
 
 
 class Transactions(object):
@@ -87,6 +68,54 @@ class Alarm(object):
         self.member_id = member_id
 
 
+class Endpoint(object):
+    """Represents an etcd cluster endpoint."""
+
+    def __init__(self, host, port, secure=True, creds=None, time_retry=300.0,
+                 opts=None):
+        self.host = host
+        self.netloc = "{host}:{port}".format(host=host, port=port)
+        self.secure = secure
+        self.protocol = 'https' if secure else 'http'
+        if self.secure and creds is None:
+            raise ValueError(
+                'Please set TLS credentials for secure connections')
+        self.credentials = creds
+        self.time_retry = 300.0
+        self.in_use = False
+        self.last_failed = 0
+        self.channel = self._mkchannel(opts)
+
+    def fail(self):
+        """Transition the endpoint to a failed state."""
+        self.in_use = False
+        self.last_failed = time.time()
+
+    def use(self):
+        """Transition the endpoint to an active state."""
+        if self.is_failed():
+            raise ValueError('Trying to use a failed node')
+        self.in_use = True
+        self.last_failed = 0
+        # TODO: is this channel always working? Maybe it's a good idea to
+        # respawn a new one?
+        return self.channel
+
+    def __str__(self):
+        return "Endpoint({}://{})".format(self.protocol, self.netloc)
+
+    def is_failed(self):
+        """Check if the current endpoint is failed."""
+        return ((time.time() - self.last_failed) < self.time_retry)
+
+    def _mkchannel(self, opts):
+        if self.secure:
+            return grpc.secure_channel(self.netloc, self.credentials,
+                                       options=opts)
+        else:
+            return grpc.insecure_channel(self.netloc, options=opts)
+
+
 class EtcdTokenCallCredentials(grpc.AuthMetadataPlugin):
     """Metadata wrapper for raw access token credentials."""
 
@@ -99,13 +128,14 @@ class EtcdTokenCallCredentials(grpc.AuthMetadataPlugin):
 
 
 class Etcd3Client(object):
-    def __init__(self, host='localhost', port=2379,
+    def __init__(self, host='localhost', port=2379, endpoints=None,
                  ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-                 user=None, password=None, grpc_options=None):
+                 user=None, password=None, grpc_options=None, failover=False):
 
-        self._url = '{host}:{port}'.format(host=host, port=port)
         self.metadata = None
+        self.failover = failover
 
+        # Step 1: verify credentials
         cert_params = [c is not None for c in (cert_cert, cert_key)]
         if ca_cert is not None:
             if all(cert_params):
@@ -115,8 +145,6 @@ class Etcd3Client(object):
                     cert_cert
                 )
                 self.uses_secure_channel = True
-                self.channel = grpc.secure_channel(self._url, credentials,
-                                                   options=grpc_options)
             elif any(cert_params):
                 # some of the cert parameters are set
                 raise ValueError(
@@ -125,26 +153,34 @@ class Etcd3Client(object):
             else:
                 credentials = self._get_secure_creds(ca_cert, None, None)
                 self.uses_secure_channel = True
-                self.channel = grpc.secure_channel(self._url, credentials,
-                                                   options=grpc_options)
         else:
             self.uses_secure_channel = False
-            self.channel = grpc.insecure_channel(self._url,
-                                                 options=grpc_options)
+            credentials = None
 
+        # Step 2: if more than one endpoint is available, add all of them, else
+        # use the host/port combination
+        if endpoints is None:
+            ep = Endpoint(host, port, secure=self.uses_secure_channel,
+                          creds=credentials, opts=grpc_options)
+            self.endpoints = {ep.netloc: ep}
+        else:
+            # If the endpoints are passed externally, just use those.
+            self.endpoints = endpoints
+
+        self._ep_in_use = random.choice(list(self.endpoints.keys()))
+
+        # Step 3: if auth is enabled, call the auth endpoint
         self.timeout = timeout
         self.call_credentials = None
-
         cred_params = [c is not None for c in (user, password)]
 
         if all(cred_params):
-            self.auth_stub = etcdrpc.AuthStub(self.channel)
             auth_request = etcdrpc.AuthenticateRequest(
                 name=user,
                 password=password
             )
 
-            resp = self.auth_stub.Authenticate(auth_request, self.timeout)
+            resp = self.authstub.Authenticate(auth_request, self.timeout)
             self.metadata = (('token', resp.token),)
             self.call_credentials = grpc.metadata_call_credentials(
                 EtcdTokenCallCredentials(resp.token))
@@ -155,17 +191,70 @@ class Etcd3Client(object):
                 'must be specified.'
             )
 
-        self.kvstub = etcdrpc.KVStub(self.channel)
-        self.watcher = watch.Watcher(
-            etcdrpc.WatchStub(self.channel),
+        # The watcher is a special beast, as it spawns threads
+        self.watcher = self.get_watcher()
+        self.transactions = Transactions()
+
+    @property
+    def authstub(self):
+        return etcdrpc.AuthStub(self.channel)
+
+    @property
+    def kvstub(self):
+        return etcdrpc.KVStub(self.channel)
+
+    @property
+    def clusterstub(self):
+        return etcdrpc.ClusterStub(self.channel)
+
+    @property
+    def leasestub(self):
+        return etcdrpc.LeaseStub(self.channel)
+
+    @property
+    def maintenancestub(self):
+        return etcdrpc.MaintenanceStub(self.channel)
+
+    def get_watcher(self):
+        watchstub = etcdrpc.WatchStub(self.channel)
+        return watch.Watcher(
+            watchstub,
             timeout=self.timeout,
             call_credentials=self.call_credentials,
             metadata=self.metadata
         )
-        self.clusterstub = etcdrpc.ClusterStub(self.channel)
-        self.leasestub = etcdrpc.LeaseStub(self.channel)
-        self.maintenancestub = etcdrpc.MaintenanceStub(self.channel)
-        self.transactions = Transactions()
+
+    @property
+    def endpoint_in_use(self):
+        """Get the current endpoint in use."""
+        if self._ep_in_use is None:
+            return None
+        return self.endpoints[self._ep_in_use]
+
+    @property
+    def channel(self):
+        """
+        Get an available channel on the first node that's not failed.
+
+        Raises an exception if no node is available
+        """
+        try:
+            return self.endpoint_in_use.use()
+        except ValueError as e:
+            if not self.failover:
+                raise
+            else:
+                pass
+        # We're failing over. We get the first non-failed channel
+        # we encounter, and use it by calling this function again,
+        # recursively
+        for label, endpoint in self.endpoints:
+            if endpoint.is_failed():
+                continue
+            self._ep_in_use = label
+            return self.channel
+        raise exceptions.NoServerAvailableError(
+            "No endpoint available and not failed")
 
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None
@@ -187,6 +276,38 @@ class Etcd3Client(object):
             cert_key_file,
             cert_cert_file
         )
+
+    def _manage_grpc_errors(self, exc):
+        code = exc.code()
+        if code in _FAILED_EP_CODES:
+            # This sets the current node to failed.
+            # If others are available, they will be used on
+            # subsequent requests.
+            # TODO: stop/respawn the watcher?
+            self.endpoint_in_use.fail()
+        exception = _EXCEPTIONS_BY_CODE.get(code)
+        if exception is None:
+            raise
+        raise exception()
+
+    def _handle_errors(payload):
+        @functools.wraps(payload)
+        def handler(self, *args, **kwargs):
+            try:
+                return payload(self, *args, **kwargs)
+            except grpc.RpcError as exc:
+                self._manage_grpc_errors(exc)
+        return handler
+
+    def _handle_generator_errors(payload):
+        @functools.wraps(payload)
+        def handler(self, *args, **kwargs):
+            try:
+                for item in payload(self, *args, **kwargs):
+                    yield item
+            except grpc.RpcError as exc:
+                self._manage_grpc_errors(exc)
+        return handler
 
     def _build_get_range_request(self, key,
                                  range_end=None,
@@ -263,7 +384,7 @@ class Etcd3Client(object):
             kv = range_response.kvs.pop()
             return kv.value, KVMetadata(kv, range_response.header)
 
-    @_handle_errors
+    @_handle_generator_errors
     def get_prefix(self, key_prefix, sort_order=None, sort_target='key'):
         """
         Get a range of keys with a prefix.
@@ -292,7 +413,7 @@ class Etcd3Client(object):
             for kv in range_response.kvs:
                 yield (kv.value, KVMetadata(kv, range_response.header))
 
-    @_handle_errors
+    @_handle_generator_errors
     def get_all(self, sort_order=None, sort_target='key'):
         """
         Get all keys currently stored in etcd.
@@ -499,17 +620,19 @@ class Etcd3Client(object):
             event_queue.put(None)
             self.cancel_watch(watch_id)
 
-        @_handle_errors
         def iterator():
-            while not canceled.is_set():
-                event = event_queue.get()
-                if event is None:
-                    canceled.set()
-                if isinstance(event, Exception):
-                    canceled.set()
-                    raise event
-                if not canceled.is_set():
-                    yield event
+            try:
+                while not canceled.is_set():
+                    event = event_queue.get()
+                    if event is None:
+                        canceled.set()
+                    if isinstance(event, Exception):
+                        canceled.set()
+                        raise event
+                    if not canceled.is_set():
+                        yield event
+            except grpc.RpcError as exc:
+                self._manage_grpc_errors(exc)
 
         return iterator(), cancel
 
@@ -697,7 +820,7 @@ class Etcd3Client(object):
             metadata=self.metadata
         )
 
-    @_handle_errors
+    @_handle_generator_errors
     def refresh_lease(self, lease_id):
         keep_alive_request = etcdrpc.LeaseKeepAliveRequest(ID=lease_id)
         request_stream = [keep_alive_request]
@@ -972,9 +1095,9 @@ class Etcd3Client(object):
             file_obj.write(response.blob)
 
 
-def client(host='localhost', port=2379,
+def client(host='localhost', port=2379, endpoints=None,
            ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-           user=None, password=None, grpc_options=None):
+           user=None, password=None, grpc_options=None, failover=False):
     """Return an instance of an Etcd3Client."""
     return Etcd3Client(host=host,
                        port=port,
@@ -984,4 +1107,5 @@ def client(host='localhost', port=2379,
                        timeout=timeout,
                        user=user,
                        password=password,
-                       grpc_options=grpc_options)
+                       grpc_options=grpc_options,
+                       failover=failover)

--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -26,3 +26,7 @@ class RevisionCompactedError(Etcd3Exception):
     def __init__(self, compacted_revision):
         self.compacted_revision = compacted_revision
         super(RevisionCompactedError, self).__init__()
+
+
+class NoServerAvailableError(Etcd3Exception):
+    pass

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -29,7 +29,8 @@ class Watch(object):
 
 class Watcher(threading.Thread):
 
-    def __init__(self, watchstub, timeout=None, call_credentials=None, metadata=None):
+    def __init__(self, watchstub, timeout=None, call_credentials=None,
+                 metadata=None):
         threading.Thread.__init__(self)
         self.timeout = timeout
         self._watch_id_callbacks = {}

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -563,39 +563,46 @@ class TestEtcd3(object):
 
     def test_internal_exception_on_internal_error(self, etcd):
         exception = self.MockedException(grpc.StatusCode.INTERNAL)
-        kv_mock = mock.MagicMock()
+        kv_mock = mock.PropertyMock()
         kv_mock.Range.side_effect = exception
-        etcd.kvstub = kv_mock
-
-        with pytest.raises(etcd3.exceptions.InternalServerError):
-            etcd.get("foo")
+        with mock.patch('etcd3.Etcd3Client.kvstub',
+                        new_callable=mock.PropertyMock) as property_mock:
+            property_mock.return_value = kv_mock
+            with pytest.raises(etcd3.exceptions.InternalServerError):
+                etcd.get("foo")
 
     def test_connection_failure_exception_on_connection_failure(self, etcd):
         exception = self.MockedException(grpc.StatusCode.UNAVAILABLE)
-        kv_mock = mock.MagicMock()
+        kv_mock = mock.PropertyMock()
         kv_mock.Range.side_effect = exception
-        etcd.kvstub = kv_mock
-
-        with pytest.raises(etcd3.exceptions.ConnectionFailedError):
-            etcd.get("foo")
+        with mock.patch('etcd3.Etcd3Client.kvstub',
+                        new_callable=mock.PropertyMock) as property_mock:
+            property_mock.return_value = kv_mock
+            with pytest.raises(etcd3.exceptions.ConnectionFailedError):
+                etcd.get("foo")
+            assert etcd.endpoint_in_use.is_failed()
 
     def test_connection_timeout_exception_on_connection_timeout(self, etcd):
         exception = self.MockedException(grpc.StatusCode.DEADLINE_EXCEEDED)
-        kv_mock = mock.MagicMock()
+        kv_mock = mock.PropertyMock()
         kv_mock.Range.side_effect = exception
-        etcd.kvstub = kv_mock
-
-        with pytest.raises(etcd3.exceptions.ConnectionTimeoutError):
-            etcd.get("foo")
+        with mock.patch('etcd3.Etcd3Client.kvstub',
+                        new_callable=mock.PropertyMock) as property_mock:
+            property_mock.return_value = kv_mock
+            with pytest.raises(etcd3.exceptions.ConnectionTimeoutError):
+                etcd.get("foo")
+            assert etcd.endpoint_in_use.is_failed()
 
     def test_grpc_exception_on_unknown_code(self, etcd):
         exception = self.MockedException(grpc.StatusCode.DATA_LOSS)
-        kv_mock = mock.MagicMock()
+        kv_mock = mock.PropertyMock()
         kv_mock.Range.side_effect = exception
-        etcd.kvstub = kv_mock
-
-        with pytest.raises(grpc.RpcError):
-            etcd.get("foo")
+        with mock.patch('etcd3.Etcd3Client.kvstub',
+                        new_callable=mock.PropertyMock) as property_mock:
+            property_mock.return_value = kv_mock
+            with pytest.raises(grpc.RpcError):
+                etcd.get("foo")
+            assert not etcd.endpoint_in_use.is_failed()
 
     def test_status_member(self, etcd):
         status = etcd.status()


### PR DESCRIPTION
This two commit add two features:
- Ability to define a list of endpoints, pass them to the client library, have it pick one at random
- Upon a connection failure, one server is marked as temporarily down and subsequent requests are made to non-failed servers. This allows i.e. to let any service running without restarts during maintenance windows  when one etcd server is either rebooted or just the service is restarted.

This is still a WiP (as you might have noticed, no docs and no additional tests, sorry but I really can only work on this on sundays :/), but I wanted to get some feedback on the direction I've taken with the code, given it is a non-negligible overhaul.

The way I built the reconnection logic might seem a bit of an overkill, but my experience with trying to build a simpler model for the etcd2 python library taught me otherwise. I tried to learn from that experience.