### PR TITLE
Add suport for user/password authentication to Etcd server

### DIFF
--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -28,7 +28,7 @@ class Watch(object):
 
 class Watcher(threading.Thread):
 
-    def __init__(self, watchstub, timeout=None):
+    def __init__(self, watchstub, timeout=None, call_credentials=None):
         threading.Thread.__init__(self)
         self.timeout = timeout
         self._watch_id_callbacks = {}
@@ -36,7 +36,8 @@ class Watcher(threading.Thread):
         self._watch_id_lock = threading.Lock()
         self._watch_requests_queue = queue.Queue()
         self._watch_response_iterator = \
-            watchstub.Watch(self._requests_iterator)
+            watchstub.Watch(self._requests_iterator,
+                            credentials=call_credentials)
         self._callback = None
         self.daemon = True
         self.start()

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -507,6 +507,12 @@ class TestClient(object):
                               cert_cert=None)
         assert client.uses_secure_channel is True
 
+    def test_secure_channel_ca_cert_and_key_raise_exception(self):
+        with pytest.raises(ValueError):
+            etcd3.client(ca_cert="tests/ca.crt",
+                         cert_key="tests/client.key",
+                         cert_cert=None)
+
     def test_user_pwd_auth(self):
         auth_mock = mock.MagicMock()
         auth_resp_mock = mock.MagicMock()

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -501,6 +501,36 @@ class TestClient(object):
                               cert_cert="tests/client.crt")
         assert client.uses_secure_channel is True
 
+    def test_secure_channel_ca_cert_only(self):
+        client = etcd3.client(ca_cert="tests/ca.crt",
+                              cert_key=None,
+                              cert_cert=None)
+        assert client.uses_secure_channel is True
+
+    def test_user_pwd_auth(self):
+        auth_mock = mock.MagicMock()
+        auth_resp_mock = mock.MagicMock()
+        auth_resp_mock.token = "the_token"
+        auth_mock.Authenticate = auth_resp_mock
+        etcdrpc.AuthStub = auth_mock
+
+        client = etcd3.client(user='some_user',
+                              password="some_pwd")
+
+        assert client.call_credentials is not None
+
+    def test_token_callback(self):
+        from etcd3.client import EtcdTokenCallCredentials
+        call_creds = EtcdTokenCallCredentials("the_token")
+
+        context_mock = mock.MagicMock()
+        callback_mock = mock.MagicMock()
+        call_creds.__call__(context_mock, callback_mock)
+
+        assert callback_mock.call_count is 1
+
+        callback_mock.assert_called_with((('token', "the_token"),), None)
+
 
 class TestCompares(object):
 


### PR DESCRIPTION
+ Provide user/password arguments to client.  When set we create a CallCredential to be passed on all subsequent calls, that passes the authenticated token.
+ Relax cert parameter restriction, only need ca_cert to validate service, when doing non-auth or credential auth over a secure channel.

While this does not provide total Auth API support, it does at least allow client to use credential authentication to a server, and should allow for what is required for #98