### PR TITLE
Add python base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.5
 
 ARG HTTP_PROXY
 ARG http_proxy


### PR DESCRIPTION
No tag was declared for the python base image. So the latest tag
was used implicitly. But, subsequent Dockerfile RUN directives were
assuming that python3.5 was present and the docker build exited with
failure, since the latest tag has moved on to newer python versions.

The docker image is now based on tag `3.5` of the python docker image.