### PR TITLE
fix all leader ID are None

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -339,9 +339,10 @@ class Etcd3Client(object):
         for m in self.members:
             if m.id == status_response.leader:
                 leader = m
-            else:
-                # raise exception?
-                leader = None
+                break
+        else:
+            # raise exception?
+            leader = None
 
         return Status(status_response.version,
                       status_response.dbSize,


### PR DESCRIPTION
In Etcd3Client.status method there is a small mistake when trying to find the leader.
Let's look at the code blow: 
```
true_leader = 2
members=(1, 2, 3)
for m_id in members:
    if m_id == true_leader:
        leader = m_id
    else:
        # raise exception?
        leader = None
# leader == None
```
In the second loop leader is set to 2, but in the third loop it's set to None again.
In this situation all members' status.leader will be set to None.
I only changed several lines:
```
true_leader = 2
members=(1, 2, 3)
for m_id in members:
    if m_id == true_leader:
        leader = m_id
        break
else:
    # raise exception?
    leader = None
# leader == 2
```
in the second loop leader is set to 2, and it breaks, so it will not be set to None