### PR TITLE
locks: fix double-acquire case

### DIFF
--- a/etcd3/locks.py
+++ b/etcd3/locks.py
@@ -42,7 +42,9 @@ class Lock(object):
 
         self.key = lock_prefix + self.name
         self.lease = None
-        self.uuid = None
+        # store uuid as bytes, since it avoids having to decode each time we
+        # need to compare
+        self.uuid = uuid.uuid1().bytes
 
     def acquire(self, timeout=10):
         """Acquire the lock.
@@ -53,10 +55,6 @@ class Lock(object):
         :returns: True if the lock has been acquired, False otherwise.
 
         """
-        # store uuid as bytes, since it avoids having to decode each time we
-        # need to compare
-        self.uuid = uuid.uuid1().bytes
-
         stop = (
             tenacity.stop_never
             if timeout is None else tenacity.stop_after_delay(timeout)

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -444,6 +444,12 @@ class TestEtcd3(object):
         assert lock1.is_acquired() is False
         assert lock2.is_acquired() is True
 
+    def test_lock_double_acquire_release(self, etcd):
+        lock = etcd.lock('lock-8', ttl=10)
+        assert lock.acquire(0) is True
+        assert lock.acquire(0) is False
+        assert lock.release() is True
+
     def test_internal_exception_on_internal_error(self, etcd):
         exception = self.MockedException(grpc.StatusCode.INTERNAL)
         kv_mock = mock.MagicMock()


### PR DESCRIPTION
When calling twice in a row acquire(), the internal uuid is regenerated, which
prevents release() to be done.