### PR TITLE
locks: fix timeout=None case

### DIFF
--- a/etcd3/locks.py
+++ b/etcd3/locks.py
@@ -61,7 +61,10 @@ class Lock(object):
         )
 
         def wait(previous_attempt_number, delay_since_first_attempt):
-            remaining_timeout = max(timeout - delay_since_first_attempt, 0)
+            if timeout is None:
+                remaining_timeout = None
+            else:
+                remaining_timeout = max(timeout - delay_since_first_attempt, 0)
             # TODO(jd): Wait for a DELETE event to happen: that'd mean the lock
             # has been released, rather than retrying on PUT events too
             try:

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -450,6 +450,13 @@ class TestEtcd3(object):
         assert lock.acquire(0) is False
         assert lock.release() is True
 
+    def test_lock_acquire_none(self, etcd):
+        lock = etcd.lock('lock-9', ttl=10)
+        assert lock.acquire(None) is True
+        # This will succeed after 10 seconds since the TTL will expire and the
+        # lock is not refreshed
+        assert lock.acquire(None) is True
+
     def test_internal_exception_on_internal_error(self, etcd):
         exception = self.MockedException(grpc.StatusCode.INTERNAL)
         kv_mock = mock.MagicMock()


### PR DESCRIPTION
The current code tries to compute (None - delay_since_first_attempt) which does
not work. Use None as timeout for watch_once when None is passed, and add a
test case.