### PR TITLE
Raise an exception when the etcd revision being watched is compacted

### DIFF
--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -20,3 +20,9 @@ class ConnectionTimeoutError(Etcd3Exception):
 
 class PreconditionFailedError(Etcd3Exception):
     pass
+
+
+class RevisionCompactedError(Etcd3Exception):
+    def __init__(self, compacted_revision):
+        self.compacted_revision = compacted_revision
+        super(RevisionCompactedError, self).__init__()


### PR DESCRIPTION
Currently in such a scenario, the watcher hangs indefinitely.
With this fix, the caller to catch the new exception and start watching
from the compacted version with a new instance of the client.