### PR TITLE
Add configurable GRPC options

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,6 +20,15 @@ This defaults to localhost, but you can specify the host and port:
 
     etcd = etcd3.client(host='etcd-host-01', port=2379)
 
+If you would like to specify options for the underlying GRPC connection, you can also pass it as a parameter:
+
+.. code-block:: python
+
+    etcd = etcd3.client(grpc_options={
+                            'grpc.http2.true_binary': 1,
+                            'grpc.http2.max_pings_without_data': 0,
+                        }.items())
+
 Putting values into etcd
 ------------------------
 

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -946,7 +946,7 @@ class Etcd3Client(object):
 
 def client(host='localhost', port=2379,
            ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-           user=None, password=None):
+           user=None, password=None, grpc_options=None):
     """Return an instance of an Etcd3Client."""
     return Etcd3Client(host=host,
                        port=port,
@@ -955,4 +955,5 @@ def client(host='localhost', port=2379,
                        cert_cert=cert_cert,
                        timeout=timeout,
                        user=user,
-                       password=password)
+                       password=password,
+                       grpc_options=grpc_options)

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -100,7 +100,7 @@ class EtcdTokenCallCredentials(grpc.AuthMetadataPlugin):
 class Etcd3Client(object):
     def __init__(self, host='localhost', port=2379,
                  ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-                 user=None, password=None):
+                 user=None, password=None, grpc_options=None):
 
         self._url = '{host}:{port}'.format(host=host, port=port)
 
@@ -113,7 +113,8 @@ class Etcd3Client(object):
                     cert_cert
                 )
                 self.uses_secure_channel = True
-                self.channel = grpc.secure_channel(self._url, credentials)
+                self.channel = grpc.secure_channel(self._url, credentials,
+                                                   options=grpc_options)
             elif any(cert_params):
                 # some of the cert parameters are set
                 raise ValueError(
@@ -122,10 +123,12 @@ class Etcd3Client(object):
             else:
                 credentials = self._get_secure_creds(ca_cert, None, None)
                 self.uses_secure_channel = True
-                self.channel = grpc.secure_channel(self._url, credentials)
+                self.channel = grpc.secure_channel(self._url, credentials,
+                                                   options=grpc_options)
         else:
             self.uses_secure_channel = False
-            self.channel = grpc.insecure_channel(self._url)
+            self.channel = grpc.insecure_channel(self._url,
+                                                 options=grpc_options)
 
         self.timeout = timeout
         self.call_credentials = None


### PR DESCRIPTION
In the current version, it is not possible to configure the underlying GRPC connection, therefore we added a parameter for it.