### PR TITLE
Lazy and fault tolerant watcher thread

### DIFF
--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -1,13 +1,18 @@
+import logging
 import threading
 
+import attr
 import grpc
-
+import six
 from six.moves import queue
 
 import etcd3.etcdrpc as etcdrpc
 import etcd3.events as events
-import etcd3.exceptions as etcd3_exceptions
+import etcd3.exceptions as exceptions
 import etcd3.utils as utils
+
+
+_log = logging.getLogger(__name__)
 
 
 class Watch(object):
@@ -23,95 +28,176 @@ class Watch(object):
     def iterator(self):
         if self.iterator is not None:
             return self.iterator
-        else:
-            raise
+
+        raise ValueError('Undefined iterator')
 
 
-class Watcher(threading.Thread):
+class Watcher(object):
 
     def __init__(self, watchstub, timeout=None, call_credentials=None, metadata=None):
-        threading.Thread.__init__(self)
         self.timeout = timeout
-        self._watch_id_callbacks = {}
-        self._watch_id_queue = queue.Queue()
-        self._watch_id_lock = threading.Lock()
-        self._watch_requests_queue = queue.Queue()
-        self._watch_response_iterator = watchstub.Watch(
-            self._requests_iterator,
-            credentials=call_credentials,
-            metadata=metadata
-        )
-        self._callback = None
-        self.daemon = True
-        self.start()
+        self._watch_stub = watchstub
+        self._credentials = call_credentials
+        self._metadata = metadata
 
-    def run(self):
-        try:
-            for response in self._watch_response_iterator:
-                if response.created:
-                    self._watch_id_callbacks[response.watch_id] = \
-                        self._callback
-                    self._watch_id_queue.put(response.watch_id)
+        self._lock = threading.Lock()
+        self._request_queue = queue.Queue(maxsize=10)
+        self._callbacks = {}
+        self._callback_thread = None
+        self._new_watch_cond = threading.Condition(lock=self._lock)
+        self._new_watch = None
 
-                callback = self._watch_id_callbacks.get(response.watch_id)
-                if callback:
-                    # The watcher can be safely reused, but adding a new event
-                    # to indicate that the revision is already compacted
-                    # requires api change which would break all users of this
-                    # module. So, raising an exception if a watcher is still
-                    # alive. The caller has to create a new client instance to
-                    # recover would break all users of this module.
-                    if response.compact_revision != 0:
-                        callback(etcd3_exceptions.RevisionCompactedError(
-                            response.compact_revision))
-                        self.cancel(response.watch_id)
-                        continue
-                    for event in response.events:
-                        callback(events.new_event(event))
-        except grpc.RpcError as e:
-            self.stop()
-            if self._watch_id_callbacks:
-                for callback in self._watch_id_callbacks.values():
-                    callback(e)
+    def add_callback(self, key, callback, range_end=None, start_revision=None,
+                     progress_notify=False, filters=None, prev_kv=False):
+        create_watch = etcdrpc.WatchCreateRequest()
+        create_watch.key = utils.to_bytes(key)
+        if range_end is not None:
+            create_watch.range_end = utils.to_bytes(range_end)
+        if start_revision is not None:
+            create_watch.start_revision = start_revision
+        if progress_notify:
+            create_watch.progress_notify = progress_notify
+        if filters is not None:
+            create_watch.filters = filters
+        if prev_kv:
+            create_watch.prev_kv = prev_kv
+        rq = etcdrpc.WatchRequest(create_request=create_watch)
 
-    @property
-    def _requests_iterator(self):
-        while True:
-            request, self._callback = self._watch_requests_queue.get()
-            if request is None:
-                break
-            yield request
+        with self._lock:
+            # Start the callback thread if it is not yet running.
+            if not self._callback_thread:
+                thread_name = 'etcd3_watch_%x' % (id(self),)
+                self._callback_thread = threading.Thread(name=thread_name,
+                                                         target=self._run)
+                self._callback_thread.daemon = True
+                self._callback_thread.start()
 
-    def add_callback(self, key, callback,
-                     range_end=None,
-                     start_revision=None,
-                     progress_notify=False,
-                     filters=None,
-                     prev_kv=False):
-        with self._watch_id_lock:
-            create_watch = etcdrpc.WatchCreateRequest()
-            create_watch.key = utils.to_bytes(key)
-            if range_end is not None:
-                create_watch.range_end = utils.to_bytes(range_end)
-            if start_revision is not None:
-                create_watch.start_revision = start_revision
-            if progress_notify:
-                create_watch.progress_notify = progress_notify
-            if filters is not None:
-                create_watch.filters = filters
-            if prev_kv:
-                create_watch.prev_kv = prev_kv
-            request = etcdrpc.WatchRequest(create_request=create_watch)
-            self._watch_requests_queue.put((request, callback))
-            return self._watch_id_queue.get(timeout=self.timeout)
+            # Only one create watch request can be pending at a time, so if
+            # there one already, then wait for it to complete first.
+            while self._new_watch:
+                self._new_watch_cond.wait()
+
+            # Submit a create watch request.
+            new_watch = _NewWatch(callback)
+            self._request_queue.put(rq)
+            self._new_watch = new_watch
+
+            # Wait for the request to be completed, or timeout.
+            self._new_watch_cond.wait(timeout=self.timeout)
+            self._new_watch = None
+
+            # If the request not completed yet, then raise a timeout exception.
+            if new_watch.id is None and new_watch.err is None:
+                raise exceptions.WatchTimedOut()
+
+            # Raise an exception if the watch request failed.
+            if new_watch.err:
+                raise new_watch.err
+
+            # Wake up threads stuck on add_callback call if any.
+            self._new_watch_cond.notify_all()
+            return new_watch.id
 
     def cancel(self, watch_id):
-        if watch_id is not None:
-            self._watch_id_callbacks.pop(watch_id, None)
-            cancel_watch = etcdrpc.WatchCancelRequest()
-            cancel_watch.watch_id = watch_id
-            request = etcdrpc.WatchRequest(cancel_request=cancel_watch)
-            self._watch_requests_queue.put((request, None))
+        with self._lock:
+            callback = self._callbacks.pop(watch_id, None)
+            if not callback:
+                return
 
-    def stop(self):
-        self._watch_requests_queue.put((None, None))
+            self._cancel_no_lock(watch_id)
+
+    def _run(self):
+        while True:
+            response_iter = self._watch_stub.Watch(
+                _new_request_iter(self._request_queue),
+                credentials=self._credentials,
+                metadata=self._metadata)
+            try:
+                for rs in response_iter:
+                    self._handle_response(rs)
+
+            except grpc.RpcError as err:
+                with self._lock:
+                    if self._new_watch:
+                        self._new_watch.err = err
+                        self._new_watch_cond.notify_all()
+
+                    callbacks = self._callbacks
+                    self._callbacks = {}
+
+                    # Rotate request queue. This way we can terminate one gRPC
+                    # stream and initiate another one whilst avoiding a race
+                    # between them over requests in the queue.
+                    self._request_queue.put(None)
+                    self._request_queue = queue.Queue(maxsize=10)
+
+                for callback in six.itervalues(callbacks):
+                    _safe_callback(callback, err)
+
+    def _handle_response(self, rs):
+        with self._lock:
+            if rs.created:
+                # If the new watch request has already expired then cancel the
+                # created watch right away.
+                if not self._new_watch:
+                    self._cancel_no_lock(rs.watch_id)
+                    return
+
+                if rs.compact_revision != 0:
+                    self._new_watch.err = exceptions.RevisionCompactedError(
+                        rs.compact_revision)
+                    return
+
+                self._callbacks[rs.watch_id] = self._new_watch.callback
+                self._new_watch.id = rs.watch_id
+                self._new_watch_cond.notify_all()
+
+            callback = self._callbacks.get(rs.watch_id)
+
+        # Ignore leftovers from canceled watches.
+        if not callback:
+            return
+
+        # The watcher can be safely reused, but adding a new event
+        # to indicate that the revision is already compacted
+        # requires api change which would break all users of this
+        # module. So, raising an exception if a watcher is still
+        # alive.
+        if rs.compact_revision != 0:
+            err = exceptions.RevisionCompactedError(rs.compact_revision)
+            _safe_callback(callback, err)
+            self.cancel(rs.watch_id)
+            return
+
+        for event in rs.events:
+            _safe_callback(callback, events.new_event(event))
+
+    def _cancel_no_lock(self, watch_id):
+        cancel_watch = etcdrpc.WatchCancelRequest()
+        cancel_watch.watch_id = watch_id
+        rq = etcdrpc.WatchRequest(cancel_request=cancel_watch)
+        self._request_queue.put(rq)
+
+
+@attr.s
+class _NewWatch(object):
+    callback = attr.ib()
+    id = attr.ib(default=None)
+    err = attr.ib(default=None)
+
+
+def _new_request_iter(_request_queue):
+    while True:
+        rq = _request_queue.get()
+        if rq is None:
+            return
+
+        yield rq
+
+
+def _safe_callback(callback, event_or_err):
+    try:
+        callback(event_or_err)
+
+    except Exception:
+        _log.exception('Watch callback failed')

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 
-import attr
 import grpc
 import six
 from six.moves import queue
@@ -179,11 +178,11 @@ class Watcher(object):
         self._request_queue.put(rq)
 
 
-@attr.s
 class _NewWatch(object):
-    callback = attr.ib()
-    id = attr.ib(default=None)
-    err = attr.ib(default=None)
+    def __init__(self, callback):
+        self.callback = callback
+        self.id = None
+        self.err = None
 
 
 def _new_request_iter(_request_queue):


### PR DESCRIPTION
### Problem
If there is no connection with etcd when `add_watch_callback` is called then the call fails with `WatchTimedOut` error and it will never be possible to create a watch using the respective client instance ever again. The root cause of that is that each client has an associated `Watcher` instance that starts a thread that terminates on any gRPC error and never started again.

### Solution
The `Watcher` thread was made not to terminate on gRPC errors. Instead it flushes all active watches and cancels pending watch create request if any and keeps running restoring the Watch stream when possible.  

Besides the `Watcher` thread is only started when the first watch is created.