### PR TITLE
Include etcd's response header in KVMetadata

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -63,12 +63,13 @@ class Transactions(object):
 
 
 class KVMetadata(object):
-    def __init__(self, keyvalue):
+    def __init__(self, keyvalue, header):
         self.key = keyvalue.key
         self.create_revision = keyvalue.create_revision
         self.mod_revision = keyvalue.mod_revision
         self.version = keyvalue.version
         self.lease_id = keyvalue.lease
+        self.response_header = header
 
 
 class Status(object):
@@ -256,7 +257,7 @@ class Etcd3Client(object):
             return None, None
         else:
             kv = range_response.kvs.pop()
-            return kv.value, KVMetadata(kv)
+            return kv.value, KVMetadata(kv, range_response.header)
 
     @_handle_errors
     def get_prefix(self, key_prefix, sort_order=None, sort_target='key'):
@@ -283,7 +284,7 @@ class Etcd3Client(object):
             return
         else:
             for kv in range_response.kvs:
-                yield (kv.value, KVMetadata(kv))
+                yield (kv.value, KVMetadata(kv, range_response.header))
 
     @_handle_errors
     def get_all(self, sort_order=None, sort_target='key'):
@@ -309,7 +310,7 @@ class Etcd3Client(object):
             return
         else:
             for kv in range_response.kvs:
-                yield (kv.value, KVMetadata(kv))
+                yield (kv.value, KVMetadata(kv, range_response.header))
 
     def _build_put_request(self, key, value, lease=None):
         put_request = etcdrpc.PutRequest()
@@ -636,7 +637,8 @@ class Etcd3Client(object):
             elif response_type == 'response_range':
                 range_kvs = []
                 for kv in response.response_range.kvs:
-                    range_kvs.append((kv.value, KVMetadata(kv)))
+                    range_kvs.append((kv.value,
+                                      KVMetadata(kv, txn_response.header)))
 
                 responses.append(range_kvs)
 

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -102,6 +102,12 @@ class TestEtcd3(object):
         assert returned == b'dootdoot'
 
     @given(characters(blacklist_categories=['Cs', 'Cc']))
+    def test_get_have_cluster_revision(self, etcd, string):
+        etcdctl('put', '/doot/' + string, 'dootdoot')
+        _, md = etcd.get('/doot/' + string)
+        assert md.response_header.revision > 0
+
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
     def test_put_key(self, etcd, string):
         etcd.put('/doot/put_1', string)
         out = etcdctl('get', '/doot/put_1')


### PR DESCRIPTION
Hi,

This PR proposes a solution to the last part of issue #53.

The situation I was in is that my program starts by getting a prefix in etcd, and then starts watching the changes to this prefix (it should react to all changes). In order to avoid missing changes between the Get and the start of the watch, the watch should start at the revision where the Get happened + 1. The API already allows to watch from a certain revision, but it did not allow to get the cluster revision when doing a Get. This PR attempts to fix that by passing the response header provided by etcd in the KVmetadata object.

This header contains 4 keys: `cluster_id` , `member_id` , `revision` and `raft_term`. The cluster revision can be retrieved like this:
```python
value, md = client.get('key')
revision = md.response_header.revision
```
I think this feature should be documented, but I am not sure where. If you point me to the right place I can write the doc.