### PR TITLE
Fix watch not working when authentication enabled on etcd3

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -159,6 +159,7 @@ class Etcd3Client(object):
             etcdrpc.WatchStub(self.channel),
             timeout=self.timeout,
             call_credentials=self.call_credentials,
+            metadata=self.metadata
         )
         self.clusterstub = etcdrpc.ClusterStub(self.channel)
         self.leasestub = etcdrpc.LeaseStub(self.channel)

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -29,7 +29,7 @@ class Watch(object):
 
 class Watcher(threading.Thread):
 
-    def __init__(self, watchstub, timeout=None, call_credentials=None):
+    def __init__(self, watchstub, timeout=None, call_credentials=None, metadata=None):
         threading.Thread.__init__(self)
         self.timeout = timeout
         self._watch_id_callbacks = {}
@@ -38,7 +38,8 @@ class Watcher(threading.Thread):
         self._watch_requests_queue = queue.Queue()
         self._watch_response_iterator = watchstub.Watch(
             self._requests_iterator,
-            credentials=call_credentials
+            credentials=call_credentials,
+            metadata=metadata
         )
         self._callback = None
         self.daemon = True


### PR DESCRIPTION
Here is a fix for my previous PR about issue #282. Watch now works with authentication.