### PR TITLE
tests: set hypothesis deadline explicitely to None

### DIFF
--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -14,7 +14,7 @@ import time
 
 import grpc
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import characters
 
 import mock
@@ -40,6 +40,11 @@ if six.PY2:
     int_types = (int, long)
 else:
     int_types = (int,)
+
+
+# Don't set any deadline in Hypothesis
+settings.register_profile("default", deadline=None)
+settings.load_profile("default")
 
 
 def etcdctl(*args):


### PR DESCRIPTION
There are warnings about the settings going from unset to 200 in a future
version, whereas the old default was None and we were good with that. Do that
explicitely.