### PR TITLE
Add close semantics to etcd client

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -171,6 +171,12 @@ class Etcd3Client(object):
         """Call the GRPC channel close semantics."""
         self.channel.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None
         cert_cert_file = None

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -82,13 +82,13 @@ class TestEtcd3(object):
         timeout = 5
         if endpoint:
             url = urlparse(endpoint)
-            client = etcd3.client(host=url.hostname,
-                                  port=url.port,
-                                  timeout=timeout)
+            with etcd3.client(host=url.hostname,
+                              port=url.port,
+                              timeout=timeout) as client:
+                yield client
         else:
-            client = etcd3.client()
-        yield client
-        client.close()
+            with etcd3.client() as client:
+                yield client
 
         @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
         def delete_keys_definitely():


### PR DESCRIPTION
This is primarily used in tests to close the grpc channel and avoid segfaults on interpreter shutdown

Feels like these semantics would be good to have regardless for anyone who wants to free resources after use of the client