### PR TITLE
Add 'prev_kv' & 'range_end' kwargs to transactional operations

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -632,7 +632,8 @@ class Etcd3Client(object):
         request_ops = []
         for op in ops:
             if isinstance(op, transactions.Put):
-                request = self._build_put_request(op.key, op.value, op.lease)
+                request = self._build_put_request(op.key, op.value,
+                                                  op.lease, op.prev_kv)
                 request_op = etcdrpc.RequestOp(request_put=request)
                 request_ops.append(request_op)
 
@@ -642,7 +643,8 @@ class Etcd3Client(object):
                 request_ops.append(request_op)
 
             elif isinstance(op, transactions.Delete):
-                request = self._build_delete_request(op.key)
+                request = self._build_delete_request(op.key,
+                                                     prev_kv=op.prev_kv)
                 request_op = etcdrpc.RequestOp(request_delete_range=request)
                 request_ops.append(request_op)
 

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -638,13 +638,13 @@ class Etcd3Client(object):
                 request_ops.append(request_op)
 
             elif isinstance(op, transactions.Get):
-                request = self._build_get_range_request(op.key)
+                request = self._build_get_range_request(op.key, op.range_end)
                 request_op = etcdrpc.RequestOp(request_range=request)
                 request_ops.append(request_op)
 
             elif isinstance(op, transactions.Delete):
-                request = self._build_delete_request(op.key,
-                                                     prev_kv=op.prev_kv)
+                request = self._build_delete_request(op.key, op.range_end,
+                                                     op.prev_kv)
                 request_op = etcdrpc.RequestOp(request_delete_range=request)
                 request_ops.append(request_op)
 

--- a/etcd3/transactions.py
+++ b/etcd3/transactions.py
@@ -72,10 +72,11 @@ class Mod(BaseCompare):
 
 
 class Put(object):
-    def __init__(self, key, value, lease=None):
+    def __init__(self, key, value, lease=None, prev_kv=False):
         self.key = key
         self.value = value
         self.lease = lease
+        self.prev_kv = prev_kv
 
 
 class Get(object):
@@ -84,5 +85,6 @@ class Get(object):
 
 
 class Delete(object):
-    def __init__(self, key):
+    def __init__(self, key, prev_kv=False):
         self.key = key
+        self.prev_kv = prev_kv

--- a/etcd3/transactions.py
+++ b/etcd3/transactions.py
@@ -80,11 +80,13 @@ class Put(object):
 
 
 class Get(object):
-    def __init__(self, key):
+    def __init__(self, key, range_end=None):
         self.key = key
+        self.range_end = range_end
 
 
 class Delete(object):
-    def __init__(self, key, prev_kv=False):
+    def __init__(self, key, range_end=None, prev_kv=False):
         self.key = key
+        self.range_end = range_end
         self.prev_kv = prev_kv


### PR DESCRIPTION
Hello, 
This PR adds to  the `put` and `delete` operations within a transaction the capability of returning the previous key-value pair, using the `prev_kv` kwarg. It also adds to transactional `get` and `delete` the capability of returning or deleting a range of keys, via the `range_end` kwarg.