### PR TITLE
Support range conditions in transactions

### DIFF
--- a/etcd3/transactions.py
+++ b/etcd3/transactions.py
@@ -10,8 +10,9 @@ _OPERATORS = {
 
 
 class BaseCompare(object):
-    def __init__(self, key):
+    def __init__(self, key, range_end=None):
         self.key = key
+        self.range_end = range_end
         self.value = None
         self.op = None
 
@@ -38,13 +39,19 @@ class BaseCompare(object):
         return self
 
     def __repr__(self):
-        return "{}: {} {} '{}'".format(self.__class__, self.key,
+        if self.range_end is None:
+            keys = self.key
+        else:
+            keys = "[{}, {})".format(self.key, self.range_end)
+        return "{}: {} {} '{}'".format(self.__class__, keys,
                                        _OPERATORS.get(self.op),
                                        self.value)
 
     def build_message(self):
         compare = etcdrpc.Compare()
         compare.key = utils.to_bytes(self.key)
+        if self.range_end is not None:
+            compare.range_end = utils.to_bytes(self.range_end)
 
         if self.op is None:
             raise ValueError('op must be one of =, !=, < or >')

--- a/etcd3/transactions.py
+++ b/etcd3/transactions.py
@@ -1,6 +1,13 @@
 import etcd3.etcdrpc as etcdrpc
 import etcd3.utils as utils
 
+_OPERATORS = {
+    etcdrpc.Compare.EQUAL: "==",
+    etcdrpc.Compare.NOT_EQUAL: "!=",
+    etcdrpc.Compare.LESS: "<",
+    etcdrpc.Compare.GREATER: ">"
+}
+
 
 class BaseCompare(object):
     def __init__(self, key):
@@ -32,14 +39,15 @@ class BaseCompare(object):
 
     def __repr__(self):
         return "{}: {} {} '{}'".format(self.__class__, self.key,
-                                       self.op, self.value)
+                                       _OPERATORS.get(self.op),
+                                       self.value)
 
     def build_message(self):
         compare = etcdrpc.Compare()
         compare.key = utils.to_bytes(self.key)
 
         if self.op is None:
-            raise ValueError('op must be one of =, < or >')
+            raise ValueError('op must be one of =, !=, < or >')
 
         compare.result = self.op
 


### PR DESCRIPTION
Hello,

This PR enables support for transaction conditions that refer to a range of keys, a feature that was introduced in etcd v3.3.