### PR TITLE
Fix naming inconsistency in environment variable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 commands=flake8 {posargs}
 
 [testenv]
-passenv = ETCD_ENDPOINT ETCD_VERSION
+passenv = ETCD_ENDPOINT TEST_ETCD_VERSION
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/etcd3
 deps=pytest-cov


### PR DESCRIPTION
This PR renames `ETCD_VERSION` to `TEST_ETCD_VERSION` in tox.ini, to match the
environment variable set in .travis.yaml.