### PR TITLE
Implement __del__ for Client objects

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -176,6 +176,9 @@ class Etcd3Client(object):
 
     def __exit__(self, *args):
         self.close()
+        
+    def __del__(self):
+        self.close()
 
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -179,7 +179,6 @@ class Etcd3Client(object):
         
     def __del__(self):
         self.close()
-
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None
         cert_cert_file = None

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -179,6 +179,7 @@ class Etcd3Client(object):
         
     def __del__(self):
         self.close()
+
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None
         cert_cert_file = None


### PR DESCRIPTION
If a user forgets to call close or use a context manager, try to cleanup grpc connections