### PR TITLE
raw string to avoid invalid escape sequence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def load_reqs(filename):
     with open(filename) as reqs_file:
         return [
             re.sub('==', '>=', line) for line in reqs_file.readlines()
-            if not re.match('\s*#', line)
+            if not re.match(r'\s*#', line)
         ]
 
 


### PR DESCRIPTION
Deprecated since Python 3.6