### PR TITLE
Clear new watch on error

### DIFF
--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -48,8 +48,9 @@ class Watcher(object):
         self._new_watch_cond = threading.Condition(lock=self._lock)
         self._new_watch = None
 
-    def add_callback(self, key, callback, range_end=None, start_revision=None,
-                     progress_notify=False, filters=None, prev_kv=False):
+    def _create_watch_request(self, key, range_end=None, start_revision=None,
+                              progress_notify=False, filters=None,
+                              prev_kv=False):
         create_watch = etcdrpc.WatchCreateRequest()
         create_watch.key = utils.to_bytes(key)
         if range_end is not None:
@@ -62,7 +63,14 @@ class Watcher(object):
             create_watch.filters = filters
         if prev_kv:
             create_watch.prev_kv = prev_kv
-        rq = etcdrpc.WatchRequest(create_request=create_watch)
+        return etcdrpc.WatchRequest(create_request=create_watch)
+
+    def add_callback(self, key, callback, range_end=None, start_revision=None,
+                     progress_notify=False, filters=None, prev_kv=False):
+        rq = self._create_watch_request(key, range_end=range_end,
+                                        start_revision=start_revision,
+                                        progress_notify=progress_notify,
+                                        filters=filters, prev_kv=prev_kv)
 
         with self._lock:
             # Start the callback thread if it is not yet running.

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -213,6 +213,19 @@ class TestEtcd3(object):
         v, _ = etcd.get('/foo/2')
         assert v is None
 
+    def test_new_watch_error(self, etcd):
+        # Trigger a failure while waiting on the new watch condition
+        with mock.patch.object(etcd.watcher._new_watch_cond, 'wait',
+                               side_effect=ValueError):
+            with pytest.raises(ValueError):
+                etcd.watch('/foo')
+
+        # Ensure a new watch can be created
+        events, cancel = etcd.watch('/foo')
+        etcdctl('put', '/foo', '42')
+        next(events)
+        cancel()
+
     def test_watch_key(self, etcd):
         def update_etcd(v):
             etcdctl('put', '/doot/watch', v)


### PR DESCRIPTION
Currently, if an exception is raised while waiting for the response to a watch create request, the new watch object is not removed from the watcher causing new watches to block forever. This PR fixes this issue by making sure the new watch object is cleaned up after an exception.

This is particularly useful when gevent is enabled, where a GreenletExit exception can by raised by wait() to kill the greenlet.