### PR TITLE
Support returning the full watch responses instead of events

### DIFF
--- a/etcd3/utils.py
+++ b/etcd3/utils.py
@@ -28,3 +28,10 @@ def lease_to_id(lease):
         except TypeError:
             pass
     return lease_id
+
+
+def response_to_event_iterator(response_iterator):
+    """Convert a watch response iterator to an event iterator."""
+    for response in response_iterator:
+        for event in response.events:
+            yield event


### PR DESCRIPTION
Add a `return_response` keyword argument to watch methods. Set `False` as its default value, so that watch retains its previous behavior of returning events one by one. If set to `True` the watch will yield the full watch responses, which contain a header and a list of events. This change makes it possible to resume a stopped watch from the last received event's modified revision + 1 without losing any events.

Closes #729.

Also, this closes #135, as it provides a way to access the header of a watch response.

Finally, this PR makes it possible to receive progress notify watch responses when `watch()` is called with `progress_notify=True`.
