### PR TITLE
add put_if_not_exists method

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -425,6 +425,31 @@ class Etcd3Client(object):
         )
 
     @_handle_errors
+    def put_if_not_exists(self, key, value, lease=None):
+        """
+        Atomically puts a value only if the key previously had no value.
+
+        This is the etcdv3 equivalent to setting a key with the etcdv2
+        parameter prevExist=false.
+
+        :param key: key in etcd to put
+        :param value: value to be written to key
+        :type value: bytes
+        :param lease: Lease to associate with this key.
+        :type lease: either :class:`.Lease`, or int (ID of lease)
+        :returns: state of transaction, ``True`` if the put was successful,
+                  ``False`` otherwise
+        :rtype: bool
+        """
+        status, _ = self.transaction(
+            compare=[self.transactions.create(key) == '0'],
+            success=[self.transactions.put(key, value, lease=lease)],
+            failure=[],
+        )
+
+        return status
+
+    @_handle_errors
     def replace(self, key, initial_value, new_value):
         """
         Atomically replace the value of a key with a new value.

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -166,6 +166,16 @@ class TestEtcd3(object):
         response = etcd.put('/doot/put_1', string, prev_kv=True)
         assert response.prev_kv.value == b'old_value'
 
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
+    def test_put_if_not_exists(self, etcd, string):
+        txn_status = etcd.put_if_not_exists('/doot/put_1', string)
+        assert txn_status is True
+
+        txn_status = etcd.put_if_not_exists('/doot/put_1', string)
+        assert txn_status is False
+
+        etcdctl('del', '/doot/put_1')
+
     def test_delete_key(self, etcd):
         etcdctl('put', '/doot/delete_this', 'delete pls')
 


### PR DESCRIPTION
I'm not sure if this should be its own method or rather we should make it a kwarg on regular put. However, because it works under a transaction it does have slightly different semantics (returns bool), it might make sense to stand on its own.