### PR TITLE
add add_watch_prefix_callback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,3 +90,12 @@ Basic usage:
 
     # cancel watch
     etcd.cancel_watch(watch_id)
+
+    # recieve watch events for a prefix via callback function
+    def watch_callback(event):
+        print(event)
+
+    watch_id = etcd.add_watch_prefix_callback("/doot/watch/prefix/", watch_callback)
+
+    # cancel watch
+    etcd.cancel_watch(watch_id)

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -572,6 +572,28 @@ class Etcd3Client(object):
             raise exceptions.WatchTimedOut()
 
     @_handle_errors
+    def add_watch_prefix_callback(self, key_prefix, callback, **kwargs):
+        """
+        Watch a prefix and call a callback on every response.
+
+        If timeout was declared during the client initialization and
+        the watch cannot be created during that time the method raises
+        a ``WatchTimedOut`` exception.
+
+        :param key_prefix: prefix to watch
+        :param callback: callback function
+
+        :returns: watch_id. Later it could be used for cancelling watch.
+        """
+        kwargs['range_end'] = \
+            utils.increment_last_byte(utils.to_bytes(key_prefix))
+
+        try:
+            return self.watcher.add_callback(key_prefix, callback, **kwargs)
+        except queue.Empty:
+            raise exceptions.WatchTimedOut()
+
+    @_handle_errors
     def watch_response(self, key, **kwargs):
         """
         Watch a key.

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -588,10 +588,7 @@ class Etcd3Client(object):
         kwargs['range_end'] = \
             utils.increment_last_byte(utils.to_bytes(key_prefix))
 
-        try:
-            return self.watcher.add_callback(key_prefix, callback, **kwargs)
-        except queue.Empty:
-            raise exceptions.WatchTimedOut()
+        return self.add_watch_callback(key_prefix, callback, **kwargs)
 
     @_handle_errors
     def watch_response(self, key, **kwargs):

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -427,13 +427,16 @@ class TestEtcd3(object):
             time.sleep(1)
 
         events = []
+
         def callback(event):
             events.extend(event.events)
 
         t = threading.Thread(name="update_key_prefix", target=update_key)
         t.start()
 
-        watch_id = etcd.add_watch_prefix_callback('/doot/watch/prefix/callback/', callback)
+        watch_id = etcd.add_watch_prefix_callback(
+            '/doot/watch/prefix/callback/', callback)
+
         t.join()
         etcd.cancel_watch(watch_id)
 
@@ -442,7 +445,6 @@ class TestEtcd3(object):
         assert events[0].value.decode() == '0'
         assert events[1].key.decode() == '/doot/watch/prefix/callback/1'
         assert events[1].value.decode() == '1'
-
 
     def test_sequential_watch_prefix_once(self, etcd):
         try:


### PR DESCRIPTION
Most of the client operations have a useful `_prefix` counterpart, except for `add_watch_callback`.

So this pull-request adds the operation `add_watch_prefix_callback` which works in the same way as `add_watch_callback`, except it's watching the prefix.