### PR TITLE
Don't close grpc channel during Etcd3Client.__del__

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -178,9 +178,6 @@ class Etcd3Client(object):
     def __exit__(self, *args):
         self.close()
 
-    def __del__(self):
-        self.close()
-
     def _get_secure_creds(self, ca_cert, cert_key=None, cert_cert=None):
         cert_key_file = None
         cert_cert_file = None


### PR DESCRIPTION
Closing the channel requires the underlying channel object to obtain a
lock, and if the lock is locked when the garbage collect runs it will
deadlock, with a stack like:

Traceback (most recent call first):
  File "/usr/lib/python3.7/threading.py", line 296, in wait
    waiter.acquire()
  File "/root/tooz/.tox/py37-etcd3/lib/python3.7/site-packages/grpc/_channel.py", line 1420, in _close
    self._channel.close(cygrpc.StatusCode.cancelled, 'Channel closed!')
  File "/root/tooz/.tox/py37-etcd3/lib/python3.7/site-packages/grpc/_channel.py", line 1436, in close
    self._close()
  File "/root/tooz/.tox/py37-etcd3/lib/python3.7/site-packages/etcd3/client.py", line 173, in close
    self.channel.close()
  File "/root/tooz/.tox/py37-etcd3/lib/python3.7/site-packages/etcd3/client.py", line 182, in __del__
    self.close()

It is generally advised to avoid taking locks while in a __del__
method.

Currently the underlying channel object does *not* close itself during
its __del__, although from this comment that may change in the future:

  # TODO(https://github.com/grpc/grpc/issues/12531): Several releases
  # after 1.12 (1.16 or thereabouts?) add a "self._channel.close" call
  # here (or more likely, call self._close() here). We don't do this
  # today because many valid use cases today allow the channel to be
  # deleted immediately after stubs are created. After a sufficient
  # period of time has passed for all users to be trusted to hang out
  # to their channels for as long as they are in use and to close them
  # after using them, then deletion of this grpc._channel.Channel
  # instance can be made to effect closure of the underlying
  # cygrpc.Channel instance.

(https://github.com/grpc/grpc/blob/ee3952f72b5b80828e9828d5170eee3f9f2c2108/src/python/grpcio/grpc/_channel.py#L1439)

We are seeing this problem manifest in the tooz project with its etcd3
backend, as the interpreter finalizes after running the test suite and
cleans up some lingering etcd3 client objects:

https://review.opendev.org/#/c/710539/