### PR TITLE
Fix thread exception

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -172,6 +172,7 @@ class Etcd3Client(object):
         """Call the GRPC channel close semantics."""
         if hasattr(self, 'channel'):
             self.channel.close()
+            self.watcher.shutdown()
 
     def __enter__(self):
         return self

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -517,7 +517,7 @@ class TestEtcd3(object):
         # Dont close channel so cleanup can still happen
         mock.patch.object(etcd.channel, 'close')
 
-        # Check that callback thread is
+        # Check that callback thread is not alive after close
         assert etcd.watcher._callback_thread.is_alive()
         etcd.close()
         assert etcd.watcher._callback_thread.is_alive() is False

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -507,6 +507,21 @@ class TestEtcd3(object):
                 assert event.value == utils.to_bytes(str(count))
                 count += 1
 
+    def test_watch_shutdown(self, etcd):
+        """
+        Test to ensure etcd.close() properly shuts down the watcher and callback thread
+        """
+        etcdctl('put', '/doot/watch', '0')
+        etcd.watch(b'/doot/watch')
+
+        # Dont close channel so cleanup can still happen
+        mock.patch.object(etcd.channel, 'close')
+
+        # Check that callback thread is
+        assert etcd.watcher._callback_thread.is_alive()
+        etcd.close()
+        assert etcd.watcher._callback_thread.is_alive() is False
+
     def test_transaction_success(self, etcd):
         etcdctl('put', '/doot/txn', 'dootdoot')
         etcd.transaction(


### PR DESCRIPTION
This change adds a shutdown method to the Watcher class.  This method signals the callback thread to terminate using a threading event.

A try catch block is also added for the expected ValueError when the grpc channel is shut down.

Functional test is included.