### PR TITLE
Enhance watcher behavior

### DIFF
--- a/etcd3/locks.py
+++ b/etcd3/locks.py
@@ -1,8 +1,8 @@
-import threading
-import time
 import uuid
 
-from etcd3 import events, exceptions
+import tenacity
+
+from etcd3 import exceptions
 
 
 class Lock(object):
@@ -55,64 +55,54 @@ class Lock(object):
         :returns: True if the lock has been acquired, False otherwise.
 
         """
-        if timeout is not None:
-            deadline = time.time() + timeout
-
-        while True:
-            if self._try_acquire():
-                return True
-
-            if timeout is not None:
-                remaining_timeout = max(deadline - time.time(), 0)
-                if remaining_timeout == 0:
-                    return False
-            else:
-                remaining_timeout = None
-
-            self._wait_delete_event(remaining_timeout)
-
-    def _try_acquire(self):
-        self.lease = self.etcd_client.lease(self.ttl)
-
-        success, metadata = self.etcd_client.transaction(
-            compare=[
-                self.etcd_client.transactions.create(self.key) == 0
-            ],
-            success=[
-                self.etcd_client.transactions.put(self.key, self.uuid,
-                                                  lease=self.lease)
-            ],
-            failure=[
-                self.etcd_client.transactions.get(self.key)
-            ]
+        stop = (
+            tenacity.stop_never
+            if timeout is None else tenacity.stop_after_delay(timeout)
         )
-        if success is True:
-            self.revision = metadata[0].response_put.header.revision
-            return True
-        self.revision = metadata[0][0][1].mod_revision
-        self.lease = None
-        return False
 
-    def _wait_delete_event(self, timeout):
+        def wait(previous_attempt_number, delay_since_first_attempt):
+            if timeout is None:
+                remaining_timeout = None
+            else:
+                remaining_timeout = max(timeout - delay_since_first_attempt, 0)
+            # TODO(jd): Wait for a DELETE event to happen: that'd mean the lock
+            # has been released, rather than retrying on PUT events too
+            try:
+                self.etcd_client.watch_once(self.key, remaining_timeout)
+            except exceptions.WatchTimedOut:
+                pass
+            return 0
+
+        @tenacity.retry(retry=tenacity.retry_never,
+                        stop=stop,
+                        wait=wait)
+        def _acquire():
+            # TODO: save the created revision so we can check it later to make
+            # sure we still have the lock
+
+            self.lease = self.etcd_client.lease(self.ttl)
+
+            success, _ = self.etcd_client.transaction(
+                compare=[
+                    self.etcd_client.transactions.create(self.key) == 0
+                ],
+                success=[
+                    self.etcd_client.transactions.put(self.key, self.uuid,
+                                                      lease=self.lease)
+                ],
+                failure=[
+                    self.etcd_client.transactions.get(self.key)
+                ]
+            )
+            if success is True:
+                return True
+            self.lease = None
+            raise tenacity.TryAgain
+
         try:
-            event_iter, cancel = self.etcd_client.watch(
-                self.key, start_revision=self.revision + 1)
-        except exceptions.WatchTimedOut:
-            return
-
-        if timeout is not None:
-            timer = threading.Timer(timeout, cancel)
-            timer.start()
-        else:
-            timer = None
-
-        for event in event_iter:
-            if isinstance(event, events.DeleteEvent):
-                if timer is not None:
-                    timer.cancel()
-
-                cancel()
-                break
+            return _acquire()
+        except tenacity.RetryError:
+            return False
 
     def release(self):
         """Release the lock."""

--- a/etcd3/utils.py
+++ b/etcd3/utils.py
@@ -1,10 +1,6 @@
-def prefix_range_end(prefix):
-    """Create a bytestring that can be used as a range_end for a prefix."""
-    s = bytearray(prefix)
-    for i in reversed(range(len(s))):
-        if s[i] < 0xff:
-            s[i] = s[i] + 1
-            break
+def increment_last_byte(byte_string):
+    s = bytearray(byte_string)
+    s[-1] = s[-1] + 1
     return bytes(s)
 
 


### PR DESCRIPTION
Expose grpc cancel error to etcd client to avoid client hang forever
Relative issue refer to https://github.com/kragniz/python-etcd3/issues/1227
Main modify in  watch.py
Root cause：1. If there is no any interacting between client and server for specific time（for example 5minutes），that leads server delete client‘s token，which client is not aware of that，when client rebuild a new watch，grpc server would return response，which response's create property is true，but cancle property also is true，in original etcd code that just judge create property，would regard this response as successful which would lead to the client thought watch request is successful, but in actually failed, therefore the client would never received any response any more. So in this fix，expose server watch cancel response as canceled exception to client to make it rebuild token
2. Fix in watcher run function handle exception part which lose control of lock part， therefore would cause concurrence problem 