### PR TITLE
Add:  handling of ResourceExhaustedError

### DIFF
--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -2,6 +2,11 @@ import functools
 import inspect
 import threading
 
+import grpc
+import grpc._channel
+
+from six.moves import queue
+
 import etcd3.etcdrpc as etcdrpc
 import etcd3.exceptions as exceptions
 import etcd3.leases as leases
@@ -10,9 +15,6 @@ import etcd3.members
 import etcd3.transactions as transactions
 import etcd3.utils as utils
 import etcd3.watch as watch
-import grpc
-import grpc._channel
-from six.moves import queue
 
 _EXCEPTIONS_BY_CODE = {
     grpc.StatusCode.INTERNAL: exceptions.InternalServerError,

--- a/etcd3/client.py
+++ b/etcd3/client.py
@@ -2,11 +2,6 @@ import functools
 import inspect
 import threading
 
-import grpc
-import grpc._channel
-
-from six.moves import queue
-
 import etcd3.etcdrpc as etcdrpc
 import etcd3.exceptions as exceptions
 import etcd3.leases as leases
@@ -15,12 +10,16 @@ import etcd3.members
 import etcd3.transactions as transactions
 import etcd3.utils as utils
 import etcd3.watch as watch
+import grpc
+import grpc._channel
+from six.moves import queue
 
 _EXCEPTIONS_BY_CODE = {
     grpc.StatusCode.INTERNAL: exceptions.InternalServerError,
     grpc.StatusCode.UNAVAILABLE: exceptions.ConnectionFailedError,
     grpc.StatusCode.DEADLINE_EXCEEDED: exceptions.ConnectionTimeoutError,
     grpc.StatusCode.FAILED_PRECONDITION: exceptions.PreconditionFailedError,
+    grpc.StatusCode.RESOURCE_EXHAUSTED: exceptions.ResourceExhaustedError,
 }
 
 

--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -28,3 +28,8 @@ class RevisionCompactedError(Etcd3Exception):
     def __init__(self, compacted_revision):
         self.compacted_revision = compacted_revision
         super(RevisionCompactedError, self).__init__()
+
+
+class ResourceExhaustedError(Etcd3Exception):
+    def __str__(self):
+        return "etcd out of memory"


### PR DESCRIPTION
This pull request adds `ResourceExhaustedError` as one of the error types that are being handled in the `etcd3-client`.
- Added `ResourceExhaustedError` as a class into `exceptions.py`
- Added `grpc.StatusCode.RESOURCE_EXHAUSTED` as one of the errortypes handled in the client
- Refactored imports with `PyCharm`'s automatic refactoring tool