### PR TITLE
fix prefix_range_end

### DIFF
--- a/etcd3/exceptions.py
+++ b/etcd3/exceptions.py
@@ -32,3 +32,7 @@ class RevisionCompactedError(Etcd3Exception):
 
 class NoServerAvailableError(Etcd3Exception):
     pass
+
+
+class NoPrefixEndError(Etcd3Exception):
+    pass

--- a/etcd3/utils.py
+++ b/etcd3/utils.py
@@ -1,11 +1,14 @@
+import etcd3.exceptions as exceptions
+
+
 def prefix_range_end(prefix):
     """Create a bytestring that can be used as a range_end for a prefix."""
     s = bytearray(prefix)
     for i in reversed(range(len(s))):
         if s[i] < 0xff:
             s[i] = s[i] + 1
-            break
-    return bytes(s)
+            return s[:i + 1]
+    raise exceptions.NoPrefixEndError()
 
 
 def to_bytes(maybe_bytestring):

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -1119,9 +1119,11 @@ class TestAlarms(object):
 class TestUtils(object):
     def test_prefix_range_end(self):
         assert etcd3.utils.prefix_range_end(b'foo') == b'fop'
-        assert etcd3.utils.prefix_range_end(b'ab\xff') == b'ac\xff'
+        assert etcd3.utils.prefix_range_end(b'ab\xff') == b'ac'
         assert (etcd3.utils.prefix_range_end(b'a\xff\xff\xff\xff\xff')
-                == b'b\xff\xff\xff\xff\xff')
+                == b'b')
+        with pytest.raises(expected_exception=etcd3.exceptions.NoPrefixEndError) :
+            etcd3.utils.prefix_range_end(b'\xff\xff\xff\xff\xff')
 
     def test_to_bytes(self):
         assert isinstance(etcd3.utils.to_bytes(b'doot'), bytes) is True


### PR DESCRIPTION
to align with etcd go client implement
https://github.com/etcd-io/etcd/blob/e591fcba335ef41f23d675563bed526d2f5bd72c/client/v3/op.go#L365

prefix_range_end(b'ab\xff') should be b'ac'