### PR TITLE
Install Python3.9 before running the CI script

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -2,6 +2,7 @@ image: archlinux
 packages:
   - python
   - python-pip
+  - python39
 sources:
   - https://github.com/kragniz/python-etcd3
 environment:


### PR DESCRIPTION
Most CI builds fail with `ERROR:  py39: InterpreterNotFound: python3.9`. It looks like the failure is because there is no python3.9 binary in recent Arch Linux images. 

This PR modifies the build script to install the missing python binary. Hopefully, this change fixes the error.