### PR TITLE
Fix slow_watch_mock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.5
+FROM python:3.9
 
 ARG HTTP_PROXY
 ARG http_proxy
 ARG HTTPS_PROXY
 ARG https_proxy
+ENV TEST_ETCD_VERSION v3.3.10
 
-RUN curl -L http://github.com/coreos/etcd/releases/download/v3.0.10/etcd-v3.0.10-linux-amd64.tar.gz | tar xzvf -
-ENV PATH $PATH:/etcd-v3.0.10-linux-amd64
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/${TEST_ETCD_VERSION}/etcd-${TEST_ETCD_VERSION}-linux-amd64.tar.gz | tar xzvf -
+ENV PATH $PATH:/etcd-${TEST_ETCD_VERSION}-linux-amd64
 
 RUN pip install -U tox
 
@@ -16,9 +17,9 @@ WORKDIR python-etcd3
 COPY tox.ini ./
 COPY requirements/base.txt requirements/test.txt ./requirements/
 
-RUN tox -epy35 --notest
+RUN tox -epy39 --notest
 
 COPY . ./
 
 ENV ETCDCTL_API 3
-CMD ["tox", "-epy35"]
+CMD ["tox", "-epy39"]

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -378,6 +378,7 @@ class TestEtcd3(object):
 
         def slow_watch_mock(*args, **kwargs):
             time.sleep(4)
+            return []
 
         foo_etcd.watcher._watch_stub.Watch = slow_watch_mock  # noqa
 


### PR DESCRIPTION
This PR fixes "TypeError: 'NoneType' object is not iterable" mentioned in https://github.com/kragniz/python-etcd3/pull/1959#issuecomment-1211745442.

This error happens because `Watcher._run` expects the `Watch` callable object returns an iterable:  

https://github.com/kragniz/python-etcd3/blob/e78000e00a25d2c3e23dbdb078eb7e20e6f5fe3d/etcd3/watch.py#L128-L136

but `slow_watch_mock`, which is used in `test_watch_timeout_on_establishment` returns nothing:

https://github.com/kragniz/python-etcd3/blob/e78000e00a25d2c3e23dbdb078eb7e20e6f5fe3d/tests/test_etcd3.py#L379-L382

This PR modifies `slow_watch_mock` to return an empty list to avoid the type error.

Also, it updates `Dockerfile` to use Python 3.9 and newer etcd.