### PR TITLE
Add support for asyncio

### DIFF
--- a/.github/workflows/python-etcd3-tests.yml
+++ b/.github/workflows/python-etcd3-tests.yml
@@ -1,0 +1,44 @@
+name: Python etcd3 tests
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Pytest python ${{ matrix.python }}, etcd ${{ matrix.etcd }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9]
+        etcd: [v3.2.32, v3.3.27]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - id: cache-etcd
+        uses: actions/cache@v3
+        with:
+          path: ~/.etcd_bin/etcd-${{ matrix.etcd }}-linux-amd64
+          key: ${{ matrix.etcd }}
+
+      - name: Setup Etcd
+        if: steps.cache-etcd.outputs.cache-hit != 'true'
+        run: |
+          curl -L https://github.com/coreos/etcd/releases/download/${{ matrix.etcd }}/etcd-${{ matrix.etcd }}-linux-amd64.tar.gz -o etcd-${{ matrix.etcd }}-linux-amd64.tar.gz
+          mkdir -p ~/.etcd_bin/
+          tar xf etcd-${{ matrix.etcd }}-linux-amd64.tar.gz -C ~/.etcd_bin/
+
+      - name: Setup Tox
+        run: pip install tox
+
+      - name: Run Tox
+        env:
+          TEST_ETCD_VERSION: ${{ matrix.etcd }}
+        run: PATH=$PATH:~/.etcd_bin/etcd-${{ matrix.etcd }}-linux-amd64 tox -e py

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ python-etcd3
 
 Python client for the etcd API v3, supported under python 2.7, 3.4 and 3.5.
 
+This library supports both synchronous and asyncio requests.
+
 **Warning: the API is mostly stable, but may change in the future**
 
 If you're interested in using this library, please get involved.
@@ -30,7 +32,8 @@ If you're interested in using this library, please get involved.
 * Free software: Apache Software License 2.0
 * Documentation: https://python-etcd3.readthedocs.io.
 
-Basic usage:
+Basic usage
+-----------
 
 .. code-block:: python
 
@@ -100,3 +103,45 @@ Basic usage:
 
     # cancel watch
     etcd.cancel_watch(watch_id)
+
+
+Asyncio usage
+-------------
+
+**:warning: Asyncio support is recent and is still experimental.**
+
+It implement the same interface as the synchronous client.
+Some requests are not yet implemented like lock, alarm or the some of the maintenance.
+
+.. code-block:: python
+
+    import etcd3
+
+    etcd = await etcd3.aioclient()
+
+    await etcd.get('foo')
+    await etcd.put('bar', 'doot')
+    await etcd.delete('bar')
+
+    # transactions
+    await etcd.transaction(
+        compare=[
+            etcd.transactions.value('/doot/testing') == 'doot',
+            etcd.transactions.version('/doot/testing') > 0,
+        ],
+        success=[
+            etcd.transactions.put('/doot/testing', 'success'),
+        ],
+        failure=[
+            etcd.transactions.put('/doot/testing', 'failure'),
+        ]
+    )
+
+    # watch key
+    watch_count = 0
+    events_iterator, cancel = await etcd.watch("/doot/watch")
+    async for event in events_iterator:
+        print(event)
+        watch_count += 1
+        if watch_count > 10:
+            await cancel()

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Asyncio usage
 **:warning: Asyncio support is recent and is still experimental.**
 
 It implement the same interface as the synchronous client.
-Some requests are not yet implemented like lock, alarm or the some of the maintenance.
+The asyncio client require Python 3.7+.
 
 .. code-block:: python
 

--- a/etcd3/__init__.py
+++ b/etcd3/__init__.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 
 import etcd3.etcdrpc as etcdrpc
 from etcd3.aioclient import aioclient
+from etcd3.aioclient import Etcd3AioClient
+from etcd3.aioclient import AioEndpoint
+from etcd3.aioclient import MultiEndpointEtcd3AioClient
 from etcd3.client import Endpoint
 from etcd3.client import Etcd3Client
 from etcd3.client import MultiEndpointEtcd3Client
@@ -19,6 +22,8 @@ __version__ = '0.12.0'
 __all__ = (
     'etcdrpc',
     'Endpoint',
+    'AioEndpoint',
+    'Etcd3AioClient',
     'Etcd3Client',
     'Etcd3Exception',
     'Transactions',
@@ -27,5 +32,6 @@ __all__ = (
     'Lease',
     'Lock',
     'Member',
-    'MultiEndpointEtcd3Client'
+    'MultiEndpointEtcd3Client',
+    'MultiEndpointEtcd3AioClient',
 )

--- a/etcd3/__init__.py
+++ b/etcd3/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import etcd3.etcdrpc as etcdrpc
+from etcd3.aioclient import aioclient
 from etcd3.client import Endpoint
 from etcd3.client import Etcd3Client
 from etcd3.client import MultiEndpointEtcd3Client
@@ -22,6 +23,7 @@ __all__ = (
     'Etcd3Exception',
     'Transactions',
     'client',
+    'aioclient',
     'Lease',
     'Lock',
     'Member',

--- a/etcd3/aioclient.py
+++ b/etcd3/aioclient.py
@@ -120,7 +120,7 @@ class MultiEndpointEtcd3AioClient(MultiEndpointEtcd3Client):
             password=password
         )
 
-        resp = await self.authstub.Authenticate(auth_request, self.timeout)
+        resp = await self.authstub.Authenticate(auth_request, timeout=self.timeout)
         self.metadata = (('token', resp.token),)
         self.call_credentials = grpc.metadata_call_credentials(
             EtcdTokenCallCredentials(resp.token))

--- a/etcd3/aioclient.py
+++ b/etcd3/aioclient.py
@@ -7,6 +7,7 @@ import grpc._channel
 import etcd3.etcdrpc as etcdrpc
 import etcd3.exceptions as exceptions
 import etcd3.leases as leases
+import etcd3.locks as locks
 import etcd3.members as members
 import etcd3.utils as utils
 import etcd3.watch as watch
@@ -707,6 +708,21 @@ class MultiEndpointEtcd3AioClient(MultiEndpointEtcd3Client):
             credentials=self.call_credentials,
             metadata=self.metadata
         )
+
+    def lock(self, name, ttl=60):
+        """
+        Create a new lock.
+
+        :param name: name of the lock
+        :type name: string or bytes
+        :param ttl: length of time for the lock to live for in seconds. The
+                    lock will be released after this time elapses, unless
+                    refreshed
+        :type ttl: int
+        :returns: new lock
+        :rtype: :class:`.Lock`
+        """
+        return locks.AioLock(name, ttl=ttl, etcd_client=self)
 
     async def get_members(self):
         """

--- a/etcd3/aioclient.py
+++ b/etcd3/aioclient.py
@@ -1,0 +1,168 @@
+import functools
+
+import grpc
+import grpc._channel
+
+import etcd3.etcdrpc as etcdrpc
+
+from etcd3.client import (
+    Endpoint,
+    MultiEndpointEtcd3Client,
+    EtcdTokenCallCredentials,
+    KVMetadata,
+)
+
+
+class AioEndpoint(Endpoint):
+    """Represents an etcd cluster endpoint for asyncio."""
+
+    def _mkchannel(self, opts):
+        if self.secure:
+            return grpc.aio.secure_channel(self.netloc, self.credentials,
+                                           options=opts)
+        else:
+            return grpc.aio.insecure_channel(self.netloc, options=opts)
+
+
+class MultiEndpointEtcd3AioClient(MultiEndpointEtcd3Client):
+    """etcd v3 API asyncio client with multiple endpoints."""
+
+    def _handle_errors(payload):
+        @functools.wraps(payload)
+        async def handler(self, *args, **kwargs):
+            try:
+                return await payload(self, *args, **kwargs)
+            except grpc.aio.AioRpcError as exc:
+                self._manage_grpc_errors(exc)
+        return handler
+
+    def _handle_generator_errors(payload):
+        @functools.wraps(payload)
+        async def handler(self, *args, **kwargs):
+            try:
+                async for item in payload(self, *args, **kwargs):
+                    yield item
+            except grpc.aio.AioRpcError as exc:
+                self._manage_grpc_errors(exc)
+        return handler
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
+
+    @_handle_errors
+    async def authenticate(self, user, password):
+        """Authenticate on the server."""
+        auth_request = etcdrpc.AuthenticateRequest(
+            name=user,
+            password=password
+        )
+
+        resp = await self.authstub.Authenticate(auth_request, self.timeout)
+        self.metadata = (('token', resp.token),)
+        self.call_credentials = grpc.metadata_call_credentials(
+            EtcdTokenCallCredentials(resp.token))
+
+    @_handle_errors
+    async def get_response(self, key, **kwargs):
+        """Get the value of a key from etcd."""
+        range_request = self._build_get_range_request(
+            key,
+            **kwargs
+        )
+
+        return await self.kvstub.Range(
+            range_request,
+            timeout=self.timeout,
+            credentials=self.call_credentials,
+            metadata=self.metadata
+        )
+
+    async def get(self, key, **kwargs):
+        """
+        Get the value of a key from etcd.
+
+        example usage:
+
+        .. code-block:: python
+
+            >>> import etcd3
+            >>> etcd = await etcd3.client()
+            >>> await etcd.get('/thing/key')
+            'hello world'
+
+        :param key: key in etcd to get
+        :returns: value of key and metadata
+        :rtype: bytes, ``KVMetadata``
+        """
+        range_response = await self.get_response(key, **kwargs)
+        if range_response.count < 1:
+            return None, None
+        else:
+            kv = range_response.kvs.pop()
+            return kv.value, KVMetadata(kv, range_response.header)
+
+
+class Etcd3AioClient(MultiEndpointEtcd3AioClient):
+    """etcd v3 API asyncio client."""
+
+    def __init__(self, host='localhost', port=2379, ca_cert=None,
+                 cert_key=None, cert_cert=None, timeout=None, user=None,
+                 password=None, grpc_options=None):
+
+        # Step 1: verify credentials
+        cert_params = [c is not None for c in (cert_cert, cert_key)]
+        if ca_cert is not None:
+            if all(cert_params):
+                credentials = self.get_secure_creds(
+                    ca_cert,
+                    cert_key,
+                    cert_cert
+                )
+                self.uses_secure_channel = True
+            elif any(cert_params):
+                # some of the cert parameters are set
+                raise ValueError(
+                    'to use a secure channel ca_cert is required by itself, '
+                    'or cert_cert and cert_key must both be specified.')
+            else:
+                credentials = self.get_secure_creds(ca_cert, None, None)
+                self.uses_secure_channel = True
+        else:
+            self.uses_secure_channel = False
+            credentials = None
+
+        # Step 2: create Endpoint
+        ep = AioEndpoint(host, port, secure=self.uses_secure_channel,
+                         creds=credentials, opts=grpc_options)
+
+        super(Etcd3AioClient, self).__init__(endpoints=[ep], timeout=timeout,
+                                             user=user, password=password)
+
+
+async def aioclient(host='localhost', port=2379,
+                    ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
+                    user=None, password=None, grpc_options=None):
+    """Return an instance of an Etcd3AioClient."""
+    client = Etcd3AioClient(host=host,
+                            port=port,
+                            ca_cert=ca_cert,
+                            cert_key=cert_key,
+                            cert_cert=cert_cert,
+                            timeout=timeout,
+                            user=user,
+                            password=password,
+                            grpc_options=grpc_options)
+
+    cred_params = [c is not None for c in (user, password)]
+    if all(cred_params):
+        await client.authenticate(user, password)
+    elif any(cred_params):
+        raise Exception(
+            'if using authentication credentials both user and password '
+            'must be specified.'
+        )
+
+    return client

--- a/etcd3/leases.py
+++ b/etcd3/leases.py
@@ -34,3 +34,53 @@ class Lease(object):
     @property
     def keys(self):
         return self._get_lease_info().keys
+
+
+class AioLease(Lease):
+    """
+    An asyncio lease.
+
+    :ivar id: ID of the lease
+    :ivar ttl: time to live for this lease
+    """
+
+    async def _get_lease_info(self):
+        return await self.etcd_client.get_lease_info(self.id)
+
+    async def revoke(self):
+        """Revoke this lease."""
+        await self.etcd_client.revoke_lease(self.id)
+
+    async def refresh(self):
+        """Refresh the time to live for this lease."""
+        return list(await self.etcd_client.refresh_lease(self.id))
+
+    async def get_remaining_ttl(self):
+        """Retrieve the remaining ttl for this lease."""
+        info = await self._get_lease_info()
+        return info.TTL
+
+    async def get_granted_ttl(self):
+        """Retrieve the initial granted ttl for this lease."""
+        info = await self._get_lease_info()
+        return info.grantedTTL
+
+    async def get_keys(self):
+        """Retrieve all keys associated with this lease."""
+        info = await self._get_lease_info()
+        return info.keys
+
+    @property
+    def remaining_ttl(self):
+        raise NotImplementedError(
+            "Use the coroutine method AioLease.get_remaining_ttl() instead.")
+
+    @property
+    def granted_ttl(self):
+        raise NotImplementedError(
+            "Use the coroutine method AioLease.get_granted_ttl() instead.")
+
+    @property
+    def keys(self):
+        raise NotImplementedError(
+            "Use the coroutine method AioLease.get_keys() instead.")

--- a/etcd3/leases.py
+++ b/etcd3/leases.py
@@ -53,7 +53,7 @@ class AioLease(Lease):
 
     async def refresh(self):
         """Refresh the time to live for this lease."""
-        return list(await self.etcd_client.refresh_lease(self.id))
+        return [response async for response in self.etcd_client.refresh_lease(self.id)]
 
     async def get_remaining_ttl(self):
         """Retrieve the remaining ttl for this lease."""

--- a/etcd3/members.py
+++ b/etcd3/members.py
@@ -43,3 +43,29 @@ class Member(object):
         :returns: Alarms
         """
         return self._etcd_client.list_alarms(member_id=self.id)
+
+
+class AioMember(Member):
+    async def remove(self):
+        """Remove this member from the cluster."""
+        await self._etcd_client.remove_member(self.id)
+
+    async def update(self, peer_urls):
+        """
+        Update the configuration of this member.
+
+        :param peer_urls: new list of peer urls the member will use to
+                          communicate with the cluster
+        """
+        await self._etcd_client.update_member(self.id, peer_urls)
+
+    async def get_active_alarms(self):
+        """Get active alarms of the member.
+        :returns: Alarms
+        """
+        return await self._etcd_client.list_alarms(member_id=self.id)
+
+    @property
+    def active_alarms(self):
+        raise NotImplementedError(
+            "Use the coroutine method AioMember.get_active_alarms() instead.")

--- a/etcd3/utils.py
+++ b/etcd3/utils.py
@@ -39,3 +39,9 @@ def response_to_event_iterator(response_iterator):
     for response in response_iterator:
         for event in response.events:
             yield event
+
+async def response_to_async_event_iterator(response_iterator):
+    """Convert a watch response async iterator to an event async iterator."""
+    async for response in response_iterator:
+        for event in response.events:
+            yield event

--- a/etcd3/watch.py
+++ b/etcd3/watch.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import threading
 
@@ -49,29 +50,12 @@ class Watcher(object):
         self._new_watch = None
         self._stopping = False
 
-    def _create_watch_request(self, key, range_end=None, start_revision=None,
-                              progress_notify=False, filters=None,
-                              prev_kv=False):
-        create_watch = etcdrpc.WatchCreateRequest()
-        create_watch.key = utils.to_bytes(key)
-        if range_end is not None:
-            create_watch.range_end = utils.to_bytes(range_end)
-        if start_revision is not None:
-            create_watch.start_revision = start_revision
-        if progress_notify:
-            create_watch.progress_notify = progress_notify
-        if filters is not None:
-            create_watch.filters.extend(filters)
-        if prev_kv:
-            create_watch.prev_kv = prev_kv
-        return etcdrpc.WatchRequest(create_request=create_watch)
-
     def add_callback(self, key, callback, range_end=None, start_revision=None,
                      progress_notify=False, filters=None, prev_kv=False):
-        rq = self._create_watch_request(key, range_end=range_end,
-                                        start_revision=start_revision,
-                                        progress_notify=progress_notify,
-                                        filters=filters, prev_kv=prev_kv)
+        rq = _create_watch_request(key, range_end=range_end,
+                                   start_revision=start_revision,
+                                   progress_notify=progress_notify,
+                                   filters=filters, prev_kv=prev_kv)
 
         with self._lock:
             # Wait for exiting thread to close
@@ -211,6 +195,120 @@ class Watcher(object):
                 self._request_queue.put(None)
 
 
+class AioWatcher:
+    def __init__(self, watchstub, timeout=None, call_credentials=None,
+                 metadata=None):
+        self.timeout = timeout
+        self._watch_stub = watchstub
+        self._credentials = call_credentials
+        self._metadata = metadata
+
+        self._lock = asyncio.Lock()
+        self._create_response_queue = asyncio.Queue(maxsize=1)
+        self._request_queue = asyncio.Queue()
+        self._stream_task = None
+        self._stream_response_iter = None
+        self._callbacks = {}
+
+    async def add_callback(self, key, callback, range_end=None,
+                           start_revision=None, progress_notify=False,
+                           filters=None, prev_kv=False):
+        async with self._lock:
+            request = _create_watch_request(key, range_end=range_end,
+                                            start_revision=start_revision,
+                                            progress_notify=progress_notify,
+                                            filters=filters, prev_kv=prev_kv)
+
+            if not self._stream_task or self._stream_task.done():
+                self._stream_task = asyncio.create_task(self.watch_stream_task())
+
+            try:
+                await asyncio.wait_for(self._request_queue.put(request),
+                                       timeout=self.timeout)
+            except asyncio.TimeoutError:
+                raise exceptions.WatchTimedOut()
+
+            try:
+                watch_id_or_err = await asyncio.wait_for(
+                    self._create_response_queue.get(), timeout=self.timeout)
+                if isinstance(watch_id_or_err, Exception):
+                    raise watch_id_or_err
+                watch_id = watch_id_or_err
+            except asyncio.TimeoutError:
+                raise exceptions.WatchTimedOut()
+
+            self._callbacks[watch_id] = callback
+            return watch_id
+
+    async def cancel(self, watch_id):
+        cancel_watch = etcdrpc.WatchCancelRequest()
+        cancel_watch.watch_id = watch_id
+        request = etcdrpc.WatchRequest(cancel_request=cancel_watch)
+        await self._request_queue.put(request)
+
+    async def watch_stream_task(self):
+        self._stream_response_iter = self._watch_stub.Watch(
+            _stream_request_iter(self._request_queue),
+            credentials=self._credentials,
+            metadata=self._metadata)
+
+        try:
+            callback_err = None
+            await self._stream_response_iter.wait_for_connection()
+            async for response in self._stream_response_iter:
+                await self._handle_response(response)
+        except Exception as err:
+            callback_err = err
+            await self._create_response_queue.put(err)
+        finally:
+            async with self._lock:
+                for callback in self._callbacks.values():
+                    await _async_safe_callback(callback, callback_err)
+
+                # Rotate request queue. This way we can terminate one gRPC
+                # stream and initiate another one whilst avoiding a race
+                # between them over requests in the queue.
+                await self._request_queue.put(None)
+                self._request_queue = asyncio.Queue()
+                self._create_response_queue = asyncio.Queue(maxsize=1)
+                self._callbacks = {}
+                print("End of task")
+
+    async def _handle_response(self, response):
+        if response.created:
+            if response.compact_revision != 0:
+                err = exceptions.RevisionCompactedError(
+                    response.compact_revision)
+                return await self._create_response_queue.put(err)
+
+            return await self._create_response_queue.put(response.watch_id)
+
+        callback = self._callbacks.get(response.watch_id)
+        if not callback:
+            return
+
+        if response.compact_revision != 0:
+            err = exceptions.RevisionCompactedError(response.compact_revision)
+            await _async_safe_callback(callback, err)
+            await self.cancel(response.watch_id)
+            return
+
+        if response.canceled:
+            return self._callbacks.pop(response.watch_id, None)
+
+        # Call the callback even when there are no events in the watch
+        # response so as not to ignore progress notify responses.
+        if response.events or not (response.created or response.canceled):
+            new_events = (events.new_event(event) for event in response.events)
+            response = WatchResponse(response.header, new_events)
+            await _async_safe_callback(callback, response)
+
+    async def close(self):
+        async with self._lock:
+            if self._stream_task or not self._stream_task.done():
+                self._stream_response_iter.cancel()
+
+
 class WatchResponse(object):
 
     def __init__(self, header, events):
@@ -225,9 +323,36 @@ class _NewWatch(object):
         self.err = None
 
 
+def _create_watch_request(key, range_end=None, start_revision=None,
+                          progress_notify=False, filters=None,
+                          prev_kv=False):
+    create_watch = etcdrpc.WatchCreateRequest()
+    create_watch.key = utils.to_bytes(key)
+    if range_end is not None:
+        create_watch.range_end = utils.to_bytes(range_end)
+    if start_revision is not None:
+        create_watch.start_revision = start_revision
+    if progress_notify:
+        create_watch.progress_notify = progress_notify
+    if filters is not None:
+        create_watch.filters.extend(filters)
+    if prev_kv:
+        create_watch.prev_kv = prev_kv
+    return etcdrpc.WatchRequest(create_request=create_watch)
+
+
 def _new_request_iter(_request_queue):
     while True:
         rq = _request_queue.get()
+        if rq is None:
+            return
+
+        yield rq
+
+
+async def _stream_request_iter(_request_queue):
+    while True:
+        rq = await _request_queue.get()
         if rq is None:
             return
 
@@ -238,5 +363,12 @@ def _safe_callback(callback, response_or_err):
     try:
         callback(response_or_err)
 
+    except Exception:
+        _log.exception('Watch callback failed')
+
+
+async def _async_safe_callback(callback, response_or_err):
+    try:
+        await callback(response_or_err)
     except Exception:
         _log.exception('Watch callback failed')

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,6 +10,7 @@ hypothesis
 more-itertools<6  # python2.7
 pytest>=4.6.5
 pytest-cov
+pytest_asyncio==0.20.3
 tox>=3.5.3
 flake8-docstrings>=1.3.0
 pydocstyle<4  # python2.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -120,11 +120,14 @@ pygments==2.9.0
     # via sphinx
 pyparsing==2.4.7
     # via packaging
+pytest-asyncio==0.20.3
+    # via -r requirements/test.in
 pytest-cov==2.12.0
     # via -r requirements/test.in
 pytest==6.2.4
     # via
     #   -r requirements/test.in
+    #   pytest-asyncio
     #   pytest-cov
 python-json-logger==2.0.1
     # via daiquiri

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -1,0 +1,92 @@
+"""Tests for `etcd3.aioclient` module."""
+
+import os
+
+import grpc
+import pytest
+import pytest_asyncio
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis.strategies import characters
+from six.moves.urllib.parse import urlparse
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+import etcd3
+import etcd3.exceptions
+
+from .test_etcd3 import etcdctl, _out_quorum
+
+etcd_version = os.environ.get('TEST_ETCD_VERSION', 'v3.2.8')
+
+os.environ['ETCDCTL_API'] = '3'
+
+
+# Don't set any deadline in Hypothesis
+settings.register_profile(
+    "default",
+    deadline=None,
+    suppress_health_check=(HealthCheck.function_scoped_fixture,))
+settings.load_profile("default")
+
+
+@pytest.mark.asyncio
+class TestEtcd3AioClient(object):
+
+    @pytest_asyncio.fixture
+    async def etcd(self):
+        client_params = {}
+        endpoint = os.environ.get('PYTHON_ETCD_HTTP_URL')
+        timeout = 5
+
+        if endpoint:
+            url = urlparse(endpoint)
+            client_params = {
+                'host': url.hostname,
+                'port': url.port,
+                'timeout': timeout,
+            }
+
+        client = await etcd3.aioclient(**client_params)
+        yield client
+
+        @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+        def delete_keys_definitely():
+            # clean up after fixture goes out of scope
+            etcdctl('del', '--prefix', '/')
+            out = etcdctl('get', '--prefix', '/')
+            assert 'kvs' not in out
+
+        delete_keys_definitely()
+
+    async def test_get_unknown_key(self, etcd):
+        value, meta = await etcd.get('probably-invalid-key')
+        assert value is None
+        assert meta is None
+
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
+    async def test_get_key(self, etcd, string):
+        etcdctl('put', '/doot/a_key', string)
+        returned, _ = await etcd.get('/doot/a_key')
+        assert returned == string.encode('utf-8')
+
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
+    async def test_get_random_key(self, etcd, string):
+        etcdctl('put', '/doot/' + string, 'dootdoot')
+        returned, _ = await etcd.get('/doot/' + string)
+        assert returned == b'dootdoot'
+
+    @given(
+        characters(blacklist_categories=['Cs', 'Cc']),
+        characters(blacklist_categories=['Cs', 'Cc']),
+    )
+    async def test_get_key_serializable(self, etcd, key, string):
+        etcdctl('put', '/doot/' + key, string)
+        with _out_quorum():
+            returned, _ = await etcd.get('/doot/' + key, serializable=True)
+        assert returned == string.encode('utf-8')
+
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
+    async def test_get_have_cluster_revision(self, etcd, string):
+        etcdctl('put', '/doot/' + string, 'dootdoot')
+        _, md = await etcd.get('/doot/' + string)
+        assert md.response_header.revision > 0

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -120,6 +120,16 @@ class TestEtcd3AioClient(object):
         response = await etcd.put('/doot/put_1', string, prev_kv=True)
         assert response.prev_kv.value == b'old_value'
 
+    @given(characters(blacklist_categories=['Cs', 'Cc']))
+    async def test_put_if_not_exists(self, etcd, string):
+        txn_status = await etcd.put_if_not_exists('/doot/put_1', string)
+        assert txn_status is True
+
+        txn_status = await etcd.put_if_not_exists('/doot/put_1', string)
+        assert txn_status is False
+
+        etcdctl('del', '/doot/put_1')
+
     async def test_delete_key(self, etcd):
         etcdctl('put', '/doot/delete_this', 'delete pls')
 
@@ -395,6 +405,118 @@ class TestEtcd3AioClient(object):
             await etcd.watch_prefix_once('/doot/', 1)
         except etcd3.exceptions.WatchTimedOut:
             pass
+
+    async def test_watch_responses(self, etcd):
+        # Test watch_response & watch_once_response
+        put_response = await etcd.put('/doot/watch', '0')
+        revision = put_response.header.revision
+        await etcd.put('/doot/watch', '1')
+        responses_iterator, cancel = \
+            await etcd.watch_response('/doot/watch', start_revision=revision)
+
+        response_1 = await responses_iterator.__anext__()
+        await cancel()
+        response_2 = await etcd.watch_once_response('/doot/watch',
+                                                    start_revision=revision)
+
+        for response in [response_1, response_2]:
+            count = 0
+            # check that the response contains the etcd revision
+            assert response.header.revision > 0
+            assert len(list(response.events)) == 2
+            for event in response.events:
+                assert event.key == b'/doot/watch'
+                assert event.value == utils.to_bytes(str(count))
+                count += 1
+
+        # Test watch_prefix_response & watch_prefix_once_response
+        success_ops = [etcd.transactions.put('/doot/watch/prefix/0', '0'),
+                       etcd.transactions.put('/doot/watch/prefix/1', '1')]
+        txn_response = await etcd.transaction([], success_ops, [])
+        revision = txn_response[1][0].response_put.header.revision
+
+        responses_iterator, cancel = \
+            await etcd.watch_prefix_response('/doot/watch/prefix/',
+                                             start_revision=revision)
+
+        response_1 = await responses_iterator.__anext__()
+        await cancel()
+        response_2 = await etcd.watch_prefix_once_response('/doot/watch/prefix/',
+                                                           start_revision=revision)
+
+        for response in [response_1, response_2]:
+            count = 0
+            assert response.header.revision == revision
+            assert len(list(response.events)) == 2
+            for event in response.events:
+                assert event.key == \
+                    utils.to_bytes('/doot/watch/prefix/{}'.format(count))
+                assert event.value == utils.to_bytes(str(count))
+                count += 1
+
+    async def test_transaction_success(self, etcd):
+        etcdctl('put', '/doot/txn', 'dootdoot')
+        await etcd.transaction(
+            compare=[etcd.transactions.value('/doot/txn') == 'dootdoot'],
+            success=[etcd.transactions.put('/doot/txn', 'success')],
+            failure=[etcd.transactions.put('/doot/txn', 'failure')]
+        )
+        out = etcdctl('get', '/doot/txn')
+        assert base64.b64decode(out['kvs'][0]['value']) == b'success'
+
+    async def test_transaction_failure(self, etcd):
+        etcdctl('put', '/doot/txn', 'notdootdoot')
+        await etcd.transaction(
+            compare=[etcd.transactions.value('/doot/txn') == 'dootdoot'],
+            success=[etcd.transactions.put('/doot/txn', 'success')],
+            failure=[etcd.transactions.put('/doot/txn', 'failure')]
+        )
+        out = etcdctl('get', '/doot/txn')
+        assert base64.b64decode(out['kvs'][0]['value']) == b'failure'
+
+    @pytest.mark.skipif(etcd_version < 'v3.3',
+                        reason="requires etcd v3.3 or higher")
+    async def test_nested_transactions(self, etcd):
+        await etcd.transaction(
+            compare=[],
+            success=[etcd.transactions.put('/doot/txn1', '1'),
+                     etcd.transactions.txn(
+                         compare=[],
+                         success=[etcd.transactions.put('/doot/txn2', '2')],
+                         failure=[])],
+            failure=[]
+        )
+        value, _ = await etcd.get('/doot/txn1')
+        assert value == b'1'
+        value, _ = await etcd.get('/doot/txn2')
+        assert value == b'2'
+
+    @pytest.mark.skipif(etcd_version < 'v3.3',
+                        reason="requires etcd v3.3 or higher")
+    async def test_transaction_range_conditions(self, etcd):
+        etcdctl('put', '/doot/key1', 'dootdoot')
+        etcdctl('put', '/doot/key2', 'notdootdoot')
+        range_end = utils.prefix_range_end(utils.to_bytes('/doot/'))
+        compare = [etcd.transactions.value('/doot/', range_end) == 'dootdoot']
+        status, _ = await etcd.transaction(compare=compare, success=[], failure=[])
+        assert not status
+        etcdctl('put', '/doot/key2', 'dootdoot')
+        status, _ = await etcd.transaction(compare=compare, success=[], failure=[])
+        assert status
+
+    async def test_replace_success(self, etcd):
+        await etcd.put('/doot/thing', 'toot')
+        status = await etcd.replace('/doot/thing', 'toot', 'doot')
+        v, _ = await etcd.get('/doot/thing')
+        assert v == b'doot'
+        assert status is True
+
+    async def test_replace_fail(self, etcd):
+        await etcd.put('/doot/thing', 'boot')
+        status = await etcd.replace('/doot/thing', 'toot', 'doot')
+        v, _ = await etcd.get('/doot/thing')
+        assert v == b'boot'
+        assert status is False
 
     async def test_get_prefix(self, etcd):
         for i in range(20):

--- a/tests/test_aioclient.py
+++ b/tests/test_aioclient.py
@@ -751,3 +751,14 @@ class TestEtcd3AioClient(object):
 
         v, _ = await etcd.get(key)
         assert v is None
+
+    async def test_member_list(self, etcd):
+        members = list(await etcd.get_members())
+        assert len(members) == 3
+        for member in members:
+            assert member.name.startswith('pifpaf')
+            for peer_url in member.peer_urls:
+                assert peer_url.startswith('http://')
+            for client_url in member.client_urls:
+                assert client_url.startswith('http://')
+            assert isinstance(member.id, int) is True

--- a/tests/test_etcd3.py
+++ b/tests/test_etcd3.py
@@ -1370,10 +1370,9 @@ class TestFailoverClient(object):
             property_mock.return_value = kv_mock
             with pytest.raises(etcd3.exceptions.ConnectionFailedError):
                 etcd.get("foo")
-        assert etcd.endpoint_in_use is original_endpoint
-        assert etcd.endpoint_in_use.is_failed()
-        etcd.get("foo")
+        assert original_endpoint.is_failed()
         assert etcd.endpoint_in_use is not original_endpoint
+        etcd.get("foo")
         assert not etcd.endpoint_in_use.is_failed()
 
     def test_failover_during_watch(self, etcd):
@@ -1404,10 +1403,9 @@ class TestFailoverClient(object):
             iterator, cancel = etcd.watch("foo")
             with pytest.raises(etcd3.exceptions.ConnectionFailedError):
                 next(iterator)
-        assert etcd.endpoint_in_use is original_endpoint
-        assert etcd.endpoint_in_use.is_failed()
-        cancel()
+        assert original_endpoint.is_failed()
         assert etcd.endpoint_in_use is not original_endpoint
+        cancel()
         assert not etcd.endpoint_in_use.is_failed()
         iterator, cancel = etcd.watch("foo")
         etcd.put("foo", b"foo")

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist=True
 commands=flake8 {posargs}
 
 [testenv]
-passenv = ETCD_ENDPOINT TEST_ETCD_VERSION
+passenv = ETCD_ENDPOINT,TEST_ETCD_VERSION
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/etcd3
 deps=


### PR DESCRIPTION
This pull request adds the asyncio support to the lib to close #616 and #1003.

I recently took over my work started in 2021 to add asyncio support. I adapted my original version to handle the changes made since 2021, in particular those related to multi endpoint.

Unlike #1177 or #633 I dont use another gRPC lib to handle asyncio requests. I use the grpcio, this allows me to have the same interface to reuse main code.
The port is not finished, there are still to do : locks, alarms and the failover.

I have re-implemented all the request's tests.

The way to use the asyncio version is very similar to the classic version :
```python
import etcd3

etcd = await etcd3.aioclient()

foo = await etcd.get('/foo')
await etcd.put('bar', 'doot')
await etcd.delete('bar')

events_iterator, cancel = await etcd.watch("/doot/watch")
async for event in events_iterator:
    print(event)
```

### TODO

- [x] get methods
- [x] put methods
- [x] replace methods
- [x] delete methods
- [x] watch methods
- [x] transactions
- [x] lease methods
- [x] members methods
- [x] compact
- [x] Finalize merge with the `MultiEndpointEtcd3Client` (some coroutine was never awaited)
- [x] status
- [x] lock methods
- [x] alarm methods
- [x] defragment
- [x] snapshot
- [x] hash
- [x] failover tests
- [x] Remaining tests

### Details

- For now the `Etcd3AioClient` inherits from the classic `MultiEndpointEtcd3Client`.
  Do I keep that or do i implement a common abstract class ?
- I don't support Python 3.6. This version is no longer active.
  But I could support it if it is a prerequisite with some adaptations.
  I tested on python 3.7, 3.8, 3.9, 3.10 (need to update dependencies), 3.11 (need to update dependencies)
- I implemented a Github Action to start tests. With the current test dependencies, tests doesn't run for ETCD v3.4+

### Tests report

https://github.com/rlegonidec/python-etcd3/actions/runs/5738790855